### PR TITLE
Support find cache + gh action for core mlc actions

### DIFF
--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -32,9 +32,9 @@ jobs:
 
     - name: Install mlcflow from the pull request's source repository and branch
       run: |
-        git clone ${{ github.event.pull_request.head.repo.html_url }} --branch=${{ github.event.pull_request.head.ref }}
-        cd mlcflow
-        pip install .
+        python -m pip install --upgrade pip
+        python -m pip install --ignore-installed --verbose pip setuptools
+        python -m pip install .
 
     - name: Test pull repo - Pull a forked MLOps repository
       run: |

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -36,41 +36,29 @@ jobs:
         python -m pip install --ignore-installed --verbose pip setuptools
         python -m pip install .
 
-    - name: Define helper functions
-      shell: bash
-      run: |
-        # Function to validate a repository after pulling
-        validate_repo() {
-          local repo_path="$1"
-          local repo_json_path="$2"
-          local expected_branch="$3"
-
-          if [ ! -d "$repo_path" ]; then
-            echo "Repository folder $repo_path not found. Exiting with failure."
-            exit 1
-          fi
-          if [ ! -f "$repo_json_path" ]; then
-            echo "File $repo_json_path does not exist. Exiting with failure."
-            exit 1
-          fi
-          if ! grep -q "$repo_path" "$repo_json_path"; then
-            echo "Path $repo_path not found in $repo_json_path. Exiting with failure."
-            exit 1
-          fi
-          CURRENT_BRANCH=$(git -C "$repo_path" rev-parse --abbrev-ref HEAD)
-          if [ "$CURRENT_BRANCH" != "$expected_branch" ]; then
-            echo "Expected branch '$expected_branch', but found '$CURRENT_BRANCH'. Exiting with failure."
-            exit 1
-          fi
-        }
-
     - name: Test 1 - pull repo - Pull a forked MLOps repository
       env:
         GH_MLC_REPO_PATH_FORK: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
         GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
-        validate_repo "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH" "dev"
+        if [ ! -d "$GH_MLC_REPO_PATH_FORK" ]; then
+          echo "Repository folder $GH_MLC_REPO_PATH_FORK not found. Exiting with failure."
+          exit 1
+        fi
+        if [ ! -f "$GH_MLC_REPO_JSON_PATH" ]; then
+          echo "File $GH_MLC_REPO_JSON_PATH does not exist. Exiting with failure."
+          exit 1
+        fi
+        if ! grep -q "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH"; then
+          echo "Path $GH_MLC_REPO_PATH_FORK not found in $GH_MLC_REPO_JSON_PATH. Exiting with failure."
+          exit 1
+        fi
+        CURRENT_BRANCH=$(git -C "$GH_MLC_REPO_PATH_FORK" rev-parse --abbrev-ref HEAD)
+        if [ "$CURRENT_BRANCH" != "dev" ]; then
+          echo "Expected branch 'dev', but found '$CURRENT_BRANCH'. Exiting with failure."
+          exit 1
+        fi
 
       
     - name: Test 2 - pull repo - Test conflicting repo scenario
@@ -79,9 +67,25 @@ jobs:
         GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc pull repo mlcommons@mlperf-automations --checkout=dev
-        validate_repo "$GH_MLC_REPO_PATH" "$GH_MLC_REPO_JSON_PATH" "dev"
-        if grep -q "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH"; then
+        if [ ! -d "$GH_MLC_REPO_PATH" ]; then
+          echo "Repository folder $GH_MLC_REPO_PATH not found. Exiting with failure."
+          exit 1
+        fi
+        if [ ! -f "$GH_MLC_REPO_JSON_PATH" ]; then
+          echo "File $GH_MLC_REPO_JSON_PATH does not exist. Exiting with failure."
+          exit 1
+        fi
+        if ! grep -q "$GH_MLC_REPO_PATH" "$GH_MLC_REPO_JSON_PATH"; then
+          echo "Path $GH_MLC_REPO_PATH not found in $GH_MLC_REPO_JSON_PATH. Exiting with failure."
+          exit 1
+        fi
+        if ! grep -q "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH"; then
           echo "Path $GH_MLC_REPO_PATH_FORK also found in $GH_MLC_REPO_JSON_PATH. This should have been replaced. Exiting with failure."
+          exit 1
+        fi
+        CURRENT_BRANCH=$(git -C "$GH_MLC_REPO_PATH" rev-parse --abbrev-ref HEAD)
+        if [ "$CURRENT_BRANCH" != "dev" ]; then
+          echo "Expected branch 'dev', but found '$CURRENT_BRANCH'. Exiting with failure."
           exit 1
         fi
     

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -40,10 +40,9 @@ jobs:
         python -m pip install .
 
     - name: Test 1 - pull repo - Pull a forked MLOps repository
-      env:
-        GH_MLC_REPO_PATH_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
+        GH_MLC_REPO_PATH_FORK="${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH="${HOME}/MLC/repos/repos.json"
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
         if [ ! -d "${GH_MLC_REPO_PATH_FORK}" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH_FORK not found. Exiting with failure."
@@ -65,10 +64,9 @@ jobs:
 
       
     - name: Test 2 - pull repo - Test conflicting repo scenario
-      env:
-        GH_MLC_REPO_PATH: "${HOME}/MLC/repos/mlcommons@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
+        GH_MLC_REPO_PATH="${HOME}/MLC/repos/mlcommons@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH="${HOME}/MLC/repos/repos.json"
         mlc pull repo mlcommons@mlperf-automations --checkout=dev
         if [ ! -d "$GH_MLC_REPO_PATH" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH not found. Exiting with failure."
@@ -97,10 +95,8 @@ jobs:
         mlc list repo
 
     - name: Test  4 - rm repo - Remove the forked mlperf-automation repo
-      env:
-        GH_MLC_REPO_PATH_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
+        GH_MLC_REPO_PATH_FORK="${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
         mlc rm repo anandhu-eng@mlperf-automations
         if [ -d "$GH_MLC_REPO_PATH_FORK" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH found. It should ideally be deleted. Exiting with failure."

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -33,11 +33,11 @@ jobs:
     - name: Test pull repo - Pull MLOps repository
       run: |
         pip install mlcflow
-        mlc pull repo anandhu-eng@mlperf-automations
+        mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
       
     - name: Test pull repo - Test conflicting repo scenario
       run: |
-        mlc pull repo mlcommons@mlperf-automations
+        mlc pull repo mlcommons@mlperf-automations --checkout=dev
     
     - name: Test list repo - List the existing repositories
       run: |

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -109,8 +109,8 @@ jobs:
 
     - name: Test 6 - run script - Output being used for testing mlc cache
       run: |
-        mlc run script --tags=get,imagenet-aux
-        mlc run script --tags=get,imagenet-aux,_from.dropbox
+        mlc run script --tags=get,imagenet-aux --quiet
+        mlc run script --tags=get,imagenet-aux,_from.dropbox --quiet
 
     - name: Test 7 - find cache - More than one cache present
       run: |

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -117,8 +117,8 @@ jobs:
 
     - name: Test 7 - find cache - More than one cache present
       run: |
-        mlc find cache --tags=get,imagenet-aux 2>&1 | tee test7.log
-        mlc find cache --tags=detect,os 2>&1 | tee test5.log
+        mlc search cache --tags=get,imagenet-aux 2>&1 | tee test7.log
+        mlc search cache --tags=detect,os 2>&1 | tee test5.log
         if grep -q "No cache entry found for the specified tags!" test5.log; then
           exit 1
         fi

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Test 1 - pull repo - Pull a forked MLOps repository
       env:
-        GH_MLC_REPO_NAME_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_PATH_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
         GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -1,0 +1,57 @@
+name: MLC core actions test
+
+on:
+  pull_request:
+    branches: [ "main", "dev" ]
+    paths:
+      - '.github/workflows/test-mlc-core-actions.yml'
+      - '**'
+      - '!**.md'
+
+jobs:
+  test_mlc_core_actions:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.8"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Configure git longpaths (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        git config --system core.longpaths true
+
+    - name: Test pull repo - Pull MLOps repository
+      run: |
+        pip install mlcflow
+        mlc pull repo anandhu-eng@mlperf-automations
+      
+    - name: Test pull repo - Test conflicting repo scenario
+      run: |
+        mlc pull repo mlcommons@mlperf-automations
+    
+    - name: Test list repo - List the existing repositories
+      run: |
+        mlc list repo
+
+    - name: Test find cache - Cache not present
+      run: |
+        mlc find cache --tags=detect,os
+
+    - name: Test run script - Output being used for testing mlc cache
+      run: |
+        mlc run script --tags=get,imagenet-aux
+        mlc run script --tags=get,imagenet-aux,_from.dropbox
+
+    - name: Test find cache - More than one cache present
+      run: |
+        mlc find cache --tags=get,imagenet-aux

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         python-version: ["3.12", "3.8"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        exclude:
+          - os: windows-latest
+          - os: macos-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +45,7 @@ jobs:
         GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
-        if [ ! -d "$GH_MLC_REPO_PATH_FORK" ]; then
+        if [ ! -d "${GH_MLC_REPO_PATH_FORK}" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH_FORK not found. Exiting with failure."
           exit 1
         fi

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -106,7 +106,7 @@ jobs:
     - name: Test 5 - find cache - Cache not present
       run: |
         mlc find cache --tags=detect,os 2>&1 | tee test5.log
-        if ! grep -q "No cache entry found for the specified tags!" test5.log; then
+        if ! grep -q "No cache entry found for the specified tags:" test5.log; then
           exit 1
         fi
 
@@ -119,6 +119,6 @@ jobs:
       run: |
         mlc search cache --tags=get,imagenet-aux 2>&1 | tee test7.log
         mlc search cache --tags=detect,os 2>&1 | tee test5.log
-        if grep -q "No cache entry found for the specified tags!" test5.log; then
+        if grep -q "No cache entry found for the specified tags:" test5.log; then
           exit 1
         fi

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -36,31 +36,86 @@ jobs:
         python -m pip install --ignore-installed --verbose pip setuptools
         python -m pip install .
 
-    - name: Test pull repo - Pull a forked MLOps repository
+    - name: Define helper functions
+      shell: bash
+      run: |
+        # Function to validate a repository after pulling
+        validate_repo() {
+          local repo_path="$1"
+          local repo_json_path="$2"
+          local expected_branch="$3"
+
+          if [ ! -d "$repo_path" ]; then
+            echo "Repository folder $repo_path not found. Exiting with failure."
+            exit 1
+          fi
+          if [ ! -f "$repo_json_path" ]; then
+            echo "File $repo_json_path does not exist. Exiting with failure."
+            exit 1
+          fi
+          if ! grep -q "$repo_path" "$repo_json_path"; then
+            echo "Path $repo_path not found in $repo_json_path. Exiting with failure."
+            exit 1
+          fi
+          CURRENT_BRANCH=$(git -C "$repo_path" rev-parse --abbrev-ref HEAD)
+          if [ "$CURRENT_BRANCH" != "$expected_branch" ]; then
+            echo "Expected branch '$expected_branch', but found '$CURRENT_BRANCH'. Exiting with failure."
+            exit 1
+          fi
+        }
+
+    - name: Test 1 - pull repo - Pull a forked MLOps repository
+      env:
+        GH_MLC_REPO_PATH_FORK: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
+        validate_repo "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH" "dev"
+
       
-    - name: Test pull repo - Test conflicting repo scenario
+    - name: Test 2 - pull repo - Test conflicting repo scenario
+      env:
+        GH_MLC_REPO_PATH: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc pull repo mlcommons@mlperf-automations --checkout=dev
+        validate_repo "$GH_MLC_REPO_PATH" "$GH_MLC_REPO_JSON_PATH" "dev"
+        if grep -q "$GH_MLC_REPO_PATH_FORK" "$GH_MLC_REPO_JSON_PATH"; then
+          echo "Path $GH_MLC_REPO_PATH_FORK also found in $GH_MLC_REPO_JSON_PATH. This should have been replaced. Exiting with failure."
+          exit 1
+        fi
     
-    - name: Test list repo - List the existing repositories
+    - name: Test 3 - list repo - List the existing repositories
       run: |
         mlc list repo
 
-    - name: Test rm repo - Remove the forked mlperf-automation repo
+    - name: Test  4 - rm repo - Remove the forked mlperf-automation repo
+      env:
+        GH_MLC_REPO_PATH_FORK: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc rm repo anandhu-eng@mlperf-automations
+        if [ -d "$GH_MLC_REPO_PATH_FORK" ]; then
+          echo "Repository folder $GH_MLC_REPO_PATH found. It should ideally be deleted. Exiting with failure."
+          exit 1
+        fi
 
-    - name: Test find cache - Cache not present
+    - name: Test 5 - find cache - Cache not present
       run: |
-        mlc find cache --tags=detect,os
+        mlc find cache --tags=detect,os 2>&1 | tee test5.log
+        if ! grep -q "No cache entry found for the specified tags!" test5.log; then
+          exit 1
+        fi
 
-    - name: Test run script - Output being used for testing mlc cache
+    - name: Test 6 - run script - Output being used for testing mlc cache
       run: |
         mlc run script --tags=get,imagenet-aux
         mlc run script --tags=get,imagenet-aux,_from.dropbox
 
-    - name: Test find cache - More than one cache present
+    - name: Test 7 - find cache - More than one cache present
       run: |
-        mlc find cache --tags=get,imagenet-aux
+        mlc find cache --tags=get,imagenet-aux 2>&1 | tee test7.log
+        mlc find cache --tags=detect,os 2>&1 | tee test5.log
+        if grep -q "No cache entry found for the specified tags!" test5.log; then
+          exit 1
+        fi

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -38,11 +38,11 @@ jobs:
 
     - name: Test 1 - pull repo - Pull a forked MLOps repository
       env:
-        GH_MLC_REPO_PATH_FORK: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_NAME_FORK: "anandhu-eng@mlperf-automations"
         GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
-        if [ ! -d "$GH_MLC_REPO_PATH_FORK" ]; then
+        if [ ! -d "$HOME/MLC/repos/$GH_MLC_REPO_PATH_FORK" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH_FORK not found. Exiting with failure."
           exit 1
         fi

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -38,11 +38,11 @@ jobs:
 
     - name: Test 1 - pull repo - Pull a forked MLOps repository
       env:
-        GH_MLC_REPO_NAME_FORK: "anandhu-eng@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
+        GH_MLC_REPO_NAME_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
-        if [ ! -d "$HOME/MLC/repos/$GH_MLC_REPO_PATH_FORK" ]; then
+        if [ ! -d "$GH_MLC_REPO_PATH_FORK" ]; then
           echo "Repository folder $GH_MLC_REPO_PATH_FORK not found. Exiting with failure."
           exit 1
         fi
@@ -63,8 +63,8 @@ jobs:
       
     - name: Test 2 - pull repo - Test conflicting repo scenario
       env:
-        GH_MLC_REPO_PATH: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
+        GH_MLC_REPO_PATH: "${HOME}/MLC/repos/mlcommons@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
         mlc pull repo mlcommons@mlperf-automations --checkout=dev
         if [ ! -d "$GH_MLC_REPO_PATH" ]; then
@@ -95,8 +95,8 @@ jobs:
 
     - name: Test  4 - rm repo - Remove the forked mlperf-automation repo
       env:
-        GH_MLC_REPO_PATH_FORK: "$HOME/MLC/repos/anandhu-eng@mlperf-automations"
-        GH_MLC_REPO_JSON_PATH: "$HOME/MLC/repos/repos.json"
+        GH_MLC_REPO_PATH_FORK: "${HOME}/MLC/repos/anandhu-eng@mlperf-automations"
+        GH_MLC_REPO_JSON_PATH: "${HOME}/MLC/repos/repos.json"
       run: |
         mlc rm repo anandhu-eng@mlperf-automations
         if [ -d "$GH_MLC_REPO_PATH_FORK" ]; then

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -30,9 +30,14 @@ jobs:
       run: |
         git config --system core.longpaths true
 
-    - name: Test pull repo - Pull MLOps repository
+    - name: Install mlcflow from the pull request's source repository and branch
       run: |
-        pip install mlcflow
+        git clone ${{ github.event.pull_request.head.repo.html_url }} --branch=${{ github.event.pull_request.head.ref }}
+        cd mlcflow
+        pip install .
+
+    - name: Test pull repo - Pull a forked MLOps repository
+      run: |
         mlc pull repo anandhu-eng@mlperf-automations  --checkout=dev
       
     - name: Test pull repo - Test conflicting repo scenario
@@ -42,6 +47,10 @@ jobs:
     - name: Test list repo - List the existing repositories
       run: |
         mlc list repo
+
+    - name: Test rm repo - Remove the forked mlperf-automation repo
+      run: |
+        mlc rm repo anandhu-eng@mlperf-automations
 
     - name: Test find cache - Cache not present
       run: |

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1077,6 +1077,7 @@ class ScriptAction(Action):
             return result
         else:
             logger.info("ScriptAutomation class not found in the script.")
+            return {'return': 1, 'error': 'ScriptAutomation class not found in the script.'}
 
     def docker(self, run_args):
         return self.call_script_module_function("docker", run_args)
@@ -1111,10 +1112,23 @@ class CacheAction(Action):
         #logger.info(f"Running script with identifier: {args.details}")
         # The REPOS folder is set by the user, for example via an environment variable.
         #logger.info(f"In cache action {repos_folder}")
-
         run_args['target_name'] = "cache"
         #print(f"run_args = {run_args}")
-        return self.search(run_args)
+        res = self.search(run_args)
+        if res['return'] > 0:
+            return res
+        else:
+            if not res['list']:
+                logger.warning("No cache entry found for the specified tags!")
+                return {'return': 0, 'list': []}
+            else:
+                logger.info("Listing all cache entries found for the specified tags.")
+                print("Cache entries:")
+                print("-------------")
+                for cache_entry in res['list']:
+                    print(f"- {cache_entry.path}\n")
+                print("-------------")
+                return {"return": 0, 'list': res['list']}
 
     def list(self, args):
         logger.info("Listing all caches.")

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1266,6 +1266,10 @@ def main():
     if hasattr(args, 'repo') and args.repo:
         run_args['repo'] = args.repo
 
+    if args.command in ['rm']:
+        if args.target == "repo":
+            run_args['repo'] = args.details
+
     if args.command in ["cp", "mv"]:
         run_args['target'] = args.target
         if hasattr(args, 'details') and args.details:

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1211,6 +1211,7 @@ class CacheAction(Action):
         i['target_name'] = "cache"
         #logger.debug(f"Searching for cache with input: {i}")
         return self.parent.search(i)
+    find = search
 
     def rm(self, i):
         i['target_name'] = "cache"


### PR DESCRIPTION
The changes proposed are to support `mlc find cache` command in MLC and to initiate the GitHub action for testing the core MLC actions.

After merging the PR, it may be observed that there are duplicate print statements of **WARNING - No cache entry found for the specified tags!** are being found when executing a script. Example is given below:

```
anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~/Music/mlcflow$ python3 -m mlc.main run script --tags=get,imagenet-aux,_from.dropbox
/usr/lib/python3.10/runpy.py:126: RuntimeWarning: 'mlc.main' found in sys.modules after import of package 'mlc', but prior to execution of 'mlc.main'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
2025-01-25 12:02:51,613 - __main__ - INFO - Repos path for Index: /home/anandhu/MLC/repos
2025-01-25 12:02:56,361 - __main__ - INFO - Shared index for script saved to /home/anandhu/MLC/repos/index_script.json.
2025-01-25 12:02:56,363 - __main__ - INFO - Shared index for cache saved to /home/anandhu/MLC/repos/index_cache.json.
2025-01-25 12:02:56,363 - __main__ - INFO - Shared index for experiment saved to /home/anandhu/MLC/repos/index_experiment.json.
2025-01-25 12:02:56,383 - root - INFO - * mlc run script --tags=get,imagenet-aux,_from.dropbox
2025-01-25 12:02:56,384 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,384 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,413 - root - INFO -   * mlc run script --tags=download-and-extract,_extract,_wget,_url.https://www.dropbox.com/s/92n2fyej3lzy3s3/caffe_ilsvrc12.tar.gz
2025-01-25 12:02:56,413 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,420 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,450 - root - INFO -     * mlc run script --tags=download,file,_wget,_url.https://www.dropbox.com/s/92n2fyej3lzy3s3/caffe_ilsvrc12.tar.gz
2025-01-25 12:02:56,450 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,451 - __main__ - WARNING - No cache entry found for the specified tags!
2025-01-25 12:02:56,466 - root - INFO -       * mlc run script --tags=detect,os
2025-01-25 12:02:56,474 - root - INFO -              ! cd /home/anandhu/MLC/repos/local/cache/download-file_e233ea24
2025-01-25 12:02:56,474 - root - INFO -              ! call /home/anandhu/MLC/repos/mlcommons@mlperf-automations/script/detect-os/run.sh from tmp-run.sh
2025-01-25 12:02:56,521 - root - INFO -              ! call "postprocess" from /ho
```

This is due to the automation script in `mlperf-automations` repo calling the `find` action of MLC. 

@arjunsuresh , would it be a good solution that we replace the calling of `find` action in `mlperf-automation` to `search`? 