### PR TITLE
Update gh actions for rm script

### DIFF
--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -175,7 +175,7 @@ jobs:
 
     - name: Test 17 - rm script
       run: |
-        mlc rm script get-ipol-src
-        mlc rm script --tags=app,image,corner-detection
-        mlc rm script 63080407db4d4ac4
+        mlc rm script get-ipol-src -f
+        mlc rm script --tags=app,image,corner-detection -f
+        mlc rm script 63080407db4d4ac4 -f
     

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -175,7 +175,7 @@ jobs:
 
     - name: Test 17 - rm script
       run: |
-        mlc rm script ipol-src
+        mlc rm script get-ipol-src
         mlc rm script --tags=app,image,corner-detection
         mlc rm script 63080407db4d4ac4
     

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -175,6 +175,7 @@ jobs:
 
     - name: Test 17 - rm script
       run: |
-        mlc rm script detect-os
-        mlc rm script --tags=detect,cpu
+        mlc rm script ipol-src
+        mlc rm script --tags=app,image,corner-detection
+        mlc rm script 63080407db4d4ac4
     


### PR DESCRIPTION
Changes:
-- use least used scripts so that more tests could be added after test-17.
-- test `rm script` by passing `uid` instead of `tags`.