### PR TITLE
RM action improvement

### DIFF
--- a/mlc/main.py
+++ b/mlc/main.py
@@ -676,6 +676,7 @@ class Action:
         dest = res['dest']
         ii = {}
         ii['item'] = src.meta['uid']
+        ii['f'] = True  # To remove the source without asking for user permission
         res = self.rm(ii)
         if res['return'] > 0:
             return res

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1718,11 +1718,6 @@ def main():
     if args.command in ['pull', 'rm', 'add', 'find']:
         if args.target == "repo":
             run_args['repo'] = args.details
-        if args.target == "script":
-            print(args.extra)
-            print(args.details)
-            if args.extra:
-                pass
   
     if hasattr(args, 'details') and args.details and "," in args.details and not run_args.get("tags") and args.target in ["script", "cache"]:
         run_args['tags'] = args.details
@@ -1741,7 +1736,6 @@ def main():
     action = get_action(args.target)
     # Dynamically call the method (e.g., run, list, show)
     if action and hasattr(action, args.command):
-        print(run_args)
         method = getattr(action, args.command)
         res = method(run_args)
         if res['return'] > 0:


### PR DESCRIPTION
Changes:

1. The target items are not removed without user prompt until `-f` flag is provided by the user for force removal(wrt. https://github.com/mlcommons/mlcflow/issues/67).
2. Add support to remove the entire cache folders with command: `mlc rm cache`