### PR TITLE
RepoAction + docs update

### DIFF
--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -196,7 +196,7 @@ jobs:
     
     - name: Test 21 - Test mlc pull repo to checkout based on particular release tag
       run: |
-        mlc rm repo mlcommons@mlperf-automations
+        mlc rm repo mlcommons@mlperf-automations -f
         mlc pull repo mlcommons@mlperf-automations --tag=mlperf-automations-v1.0.0
 
   test_mlc_access_core_actions:

--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -193,6 +193,11 @@ jobs:
     - name: Test 20 - list cache
       run: |
         mlc list cache
+    
+    - name: Test 21 - Test mlc pull repo to checkout based on particular release tag
+      run: |
+        mlc rm repo mlcommons@mlperf-automations
+        mlc pull repo mlcommons@mlperf-automations --tag=mlperf-automations-v1.0.0
 
   test_mlc_access_core_actions:
 

--- a/docs/targets/repo/index.md
+++ b/docs/targets/repo/index.md
@@ -2,94 +2,169 @@
 
 Currently, the following actions are supported for repos:
 
-## Add
+## **Syntax Variations**  
 
-`add` action is used to create a new MLC repo and register in MLCFlow. The newly created repo folder would be present inside the `repos` folder present inside the parent `MLC` folder.
+In MLCFlow, repos can be identified in different ways:  
 
-**Syntax**
+1. **Using MLC repo folder name format:** `<repoowner@reponame>` (e.g.,`mlcommons@mlperf-automations`)
+2. **Using alias:** `<repo_alias>`  (e.g., `mlcommons@mlperf-automations`)  
+3. **Using UID:** `<repo_uid>`  (e.g., `9cf241afa6074c89`)  
+4. **Using both alias and UID:** `<repo_alias>,<repo_uid>` (e.g., `mlcommons@mlperf-automations,9cf241afa6074c89`)
+5. **Using URL:** `<repo_url>` (e.g., `https://github.com/mlcommons/mlperf-automations`)  
 
-```bash
-mlc add repo <repo_name/github_link>
-```
-
-Examples of `add` action for `repo` target could be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
+!!! note  
+    - `repo uid` and `repo alias` for a particular MLC repository can be found inside `meta.yml` file.
+    - For simplicity, syntax variations are only shown for the `find` action, but similar options apply to all other actions.  
 
 ## Find
 
-`find` action is used to get the path of a particular repository registered in MLCFlow. 
+`find` action retrieves the path of a specific repository registered in MLCFlow.
 
-**Syntax**
+### **Syntax Variations**  
+
+| Command Format | Example Usage |
+|---------------|--------------|
+| `mlc find repo <repo_owner@repo_name>` | `mlc find repo mlcommons@mlperf-automations` |
+| `mlc find repo <repo_alias>` | `mlc find repo mlcommons@mlperf-automations` |
+| `mlc find repo <repo_uid>` | `mlc find repo 9cf241afa6074c89` |
+| `mlc find script <repo_alias>,<repo_uid>` | `mlc find repo mlcommons@mlperf-automations,9cf241afa6074c89` |
+| `mlc find repo <repo_url>` | `mlc find repo https://github.com/mlcommons/mlperf-automations` |
+
+Examples of `find` action for `repo` target can be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
+
+<details>
+  <summary><strong>Example Output</strong> 📌</summary>
+
+  ```bash
+  anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~$ mlc find repo mlcommons@mlperf-automations
+  [2025-02-19 15:32:18,352 main.py:1737 INFO] - Item path: /home/anandhu/MLC/repos/mlcommons@mlperf-automations
+  ```
+</details>  
+
+## Add
+
+`add` action is used to create a new MLC repo and register in MLCFlow. The newly created repo folder will be present inside the `repos` folder within the parent `MLC` directory.
+
+**Example Command**
 
 ```bash
-mlc find repo <repo_owner@repo_name>
+mlc add repo mlcommons@script-automations
 ```
+<details>
+  <summary><strong>Example Output</strong> 📌</summary>
 
-OR
+  ```bash
+    anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~$ mlc add repo mlcommons@script-automations
+    [2025-02-19 16:34:37,570 main.py:1085 INFO] - New repo path: /home/anandhu/MLC/repos/mlcommons@script-automations
+    [2025-02-19 16:34:37,573 main.py:1126 INFO] - Added new repo path: /home/anandhu/MLC/repos/mlcommons@script-automations
+    [2025-02-19 16:34:37,573 main.py:1130 INFO] - Updated repos.json at /home/anandhu/MLC/repos/repos.json
+  ```
+</details>  
 
-```bash
-mlc find repo <repo_url>
-```
+Examples of `add` action for `repo` target could be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
 
-OR
-
-```bash
-mlc find repo <repo_uid>
-```
-
-OR
-
-```bash
-mlc find repo <repo_alias>
-```
-
-OR
-
-```bash
-mlc find repo <repo_alias>,<repo_uid>
-```
-
-Examples of `find` action for `repo` target could be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
+!!! note  
+    - `repo_uid` is not supported in the `add` action for `repo` target since `uid` for the repo is assigned automatically while creating the repository. 
 
 ## Pull
 
-`pull` action is used to clone a MLC repo and register in MLC.
+`pull` action clones an MLC repository and registers it in MLC.
 
-**Syntax**
+If the repository already exists locally in MLC repos directory, it fetches the latest changes if there are no uncommited modifications(does not include untracked files/folders). The `pull` action could be also used to checkout to a particular branch or release tag with flags `--checkout` and `--tag`.
 
-```bash
-mlc pull repo <repo_owner>@<repo_name>
-```
-
-OR
+**Example Command**
 
 ```bash
-mlc pull repo <repo_urll>
+mlc pull repo mlcommons@mlperf-automations
 ```
 
-- The `--checkout` flag can be used if a user needs to check out a specific commit after cloning. The user must provide the commit SHA.
-- The `--branch` flag can be used if a user needs to check out a specific branch after cloning. The user must provide the branch name.
+<details>
+  <summary><strong>Example Output</strong> 📌</summary>
+
+  ```bash
+    anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~$ mlc pull repo mlcommons@mlperf-automations
+    [2025-02-19 16:46:27,208 main.py:1260 INFO] - Cloning repository https://github.com/mlcommons/mlperf-automations.git to /home/anandhu/MLC/repos/mlcommons@mlperf-automations...
+    Cloning into '/home/anandhu/MLC/repos/mlcommons@mlperf-automations'...
+    remote: Enumerating objects: 77610, done.
+    remote: Counting objects: 100% (2199/2199), done.
+    remote: Compressing objects: 100% (1103/1103), done.
+    remote: Total 77610 (delta 1616), reused 1109 (delta 1095), pack-reused 75411 (from 2)
+    Receiving objects: 100% (77610/77610), 18.36 MiB | 672.00 KiB/s, done.
+    Resolving deltas: 100% (53818/53818), done.
+    [2025-02-19 16:46:57,604 main.py:1288 INFO] - Repository successfully pulled.
+    [2025-02-19 16:46:57,605 main.py:1289 INFO] - Registering the repo in repos.json
+    [2025-02-19 16:46:57,605 main.py:1126 INFO] - Added new repo path: /home/anandhu/MLC/repos/mlcommons@mlperf-automations
+    [2025-02-19 16:46:57,606 main.py:1130 INFO] - Updated repos.json at /home/anandhu/MLC/repos/repos.json
+  ```
+</details>  
+
+
+- The `--checkout` flag can be used if a user needs to check out a specific commit or branch after cloning. The user must provide the commit SHA if they want to check out a specific commit. This flag can be used in cases where the repository exists locally.
+- The `--branch` flag can be used if a user needs to check out a specific branch after cloning. The user must provide the branch name. This flag will only work when cloning a new repository.
+- The `--tag` flag can be used to check out a particular release tag.
+- `--pat=<access_token>` or `--ssh` flag can be used to clone a private repository.
 
 Examples of `pull` action for `repo` target could be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
 
+!!! note  
+    - `repo_uid` and `repo_alias` are not supported in the `pull` action for the `repo` target.  
+    - Only one of `--checkout`, `--branch`, or `--tag` should be specified when using this action.  
+
 ## List
 
-`list` action is used to list the alias and path of the MLC repos registered in MLC.
+`list` action displays all registered MLC repositories along with their aliases and paths.
 
-**Syntax**
+**Example Command**
 
 ```bash
 mlc list repo
 ```
+
+<details>
+  <summary><strong>Example Output</strong> 📌</summary>
+
+  ```bash
+    anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~$ mlc list repo
+    [2025-02-19 16:56:31,847 main.py:1349 INFO] - Listing all repositories.
+
+    Repositories:
+    -------------
+    - Alias: local
+    Path:  /home/anandhu/MLC/repos/local
+
+    -  Alias: mlcommons@mlperf-automations
+    Path:  /home/anandhu/MLC/repos/mlcommons@mlperf-automations
+
+    -------------
+    [2025-02-19 16:56:31,850 main.py:1356 INFO] - Repository listing ended
+
+  ```
+</details>  
+
 Example of `list` action for `repo` target could be found inside the GitHub action workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
 
 ## Rm (Remove)
 
-`rm` action is used to remove the specified repo registered in MLC.
+`rm` action removes a specified repository from MLCFlow, deleting both the repo folder and its registration.
 
-**Syntax**
+**Example Command**
 
 ```bash
-mlc rm repo <repo_owner>@<repo_name>
+mlc rm repo mlcommons@mlperf-automations
 ```
+
+<details>
+    <summary><strong>Example Output</strong></summary>
+
+    ```bash
+        anandhu@anandhu-VivoBook-ASUSLaptop-X515UA-M515UA:~$ mlc rm repo mlcommons@mlperf-automations
+        [2025-02-19 17:01:59,483 main.py:1360 INFO] - rm command has been called for repo. This would delete the repo folder and unregister the repo from repos.json
+        [2025-02-19 17:01:59,521 main.py:1380 INFO] - No local changes detected. Removing repo...
+        [2025-02-19 17:01:59,581 main.py:1384 INFO] - Repo mlcommons@mlperf-automations residing in path /home/anandhu/MLC/repos/mlcommons@mlperf-automations has been successfully removed
+        [2025-02-19 17:01:59,581 main.py:1385 INFO] - Checking whether the repo was registered in repos.json
+        [2025-02-19 17:01:59,581 main.py:1134 INFO] - Unregistering the repo in path /home/anandhu/MLC/repos/mlcommons@mlperf-automations
+        [2025-02-19 17:01:59,581 main.py:1144 INFO] - Path: /home/anandhu/MLC/repos/mlcommons@mlperf-automations has been removed.
+    ```
+
 An example of the `rm` action for the `repo` target can be found in the GitHub Actions workflow [here](https://github.com/mlcommons/mlcflow/blob/d0269b47021d709e0ffa7fe0db8c79635bfd9dff/.github/workflows/test-mlc-core-actions.yaml).
 

--- a/docs/targets/repo/index.md
+++ b/docs/targets/repo/index.md
@@ -145,7 +145,7 @@ Example of `list` action for `repo` target could be found inside the GitHub acti
 
 ## Rm (Remove)
 
-`rm` action removes a specified repository from MLCFlow, deleting both the repo folder and its registration.
+`rm` action removes a specified repository from MLCFlow, deleting both the repo folder and its registration. If there are any modified local changes, the user will be prompted for confirmation unless the `-f` flag is used to force removal.
 
 **Example Command**
 

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1300,8 +1300,9 @@ class RepoAction(Action):
                 logger.info(f"Checking out to {checkout} in {repo_path}...")
                 subprocess.run(['git', '-C', repo_path, 'checkout', checkout], check=True)
             
-            subprocess.run(['git', '-C', repo_path, 'pull'], check=True)
-            
+            if not tag:
+                subprocess.run(['git', '-C', repo_path, 'pull'], check=True)
+
             logger.info("Repository successfully pulled.")
             logger.info("Registering the repo in repos.json")
 

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1291,7 +1291,6 @@ class RepoAction(Action):
                 else:
                     logger.info("No local changes detected. Fetching latest changes...")
                     subprocess.run(['git', '-C', repo_path, 'fetch'], check=True)
-                    subprocess.run(['git', '-C', repo_path, 'pull'], check=True)
             
             if tag:
                 checkout = "tags/"+tag
@@ -1300,6 +1299,8 @@ class RepoAction(Action):
             if checkout or tag:
                 logger.info(f"Checking out to {checkout} in {repo_path}...")
                 subprocess.run(['git', '-C', repo_path, 'checkout', checkout], check=True)
+            
+            subprocess.run(['git', '-C', repo_path, 'pull'], check=True)
             
             logger.info("Repository successfully pulled.")
             logger.info("Registering the repo in repos.json")

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1360,9 +1360,6 @@ class RepoAction(Action):
             if sum(bool(var) for var in [branch, checkout, tag]) > 1:
                     return {"return": 1, "error": "Only one among the three flags(branch, checkout and tag) could be specified"}
             
-            if sum(bool(var) for var in [pat, ssh]) > 1:
-                    return {"return": 1, "error": "Only one among the two flags(pat, ssh) could be specified"}
-            
             res = self.pull_repo(repo_url, branch, checkout, tag, pat, ssh)
             if res['return'] > 0:
                 return res

--- a/mlc/main.py
+++ b/mlc/main.py
@@ -1291,6 +1291,7 @@ class RepoAction(Action):
                 else:
                     logger.info("No local changes detected. Fetching latest changes...")
                     subprocess.run(['git', '-C', repo_path, 'fetch'], check=True)
+                    subprocess.run(['git', '-C', repo_path, 'pull'], check=True)
             
             if tag:
                 checkout = "tags/"+tag

--- a/mlc/utils.py
+++ b/mlc/utils.py
@@ -611,6 +611,25 @@ def get_new_uid():
         return {"return": 0, "uid": new_uid}
     except Exception as e:
         return {"return": 1, "error": f"Failed to generate UID: {str(e)}"}
+    
+def modify_git_url(get_type, url, params={}):
+    """
+    Modify the GitHub url to support cloning of repo with either ssh or pat
+
+    Returns:
+        dict: A dictionary containing:
+            - return (int): 0 if successful, >0 if there was an error.
+            - url (str): Modified git url.
+    """
+    from giturlparse import parse
+    p = parse(url)
+    if get_type == "ssh":
+        return {"return": 0, "url": p.url2ssh }
+    elif get_type == "pat":
+        token = params['token']
+        return {"return": 0, "url":"https://git:" + token + "@" + p.host + "/" + p.owner + "/" + p.repo }
+    else:
+        return {"return": 1, "error": f"Unsupported type: {get_type}"}
 
 def convert_tags_to_list(tags_string):
     """


### PR DESCRIPTION
- Add support for cloning private repositories.
- Add support for checkout based on particular release tags.
- Repo Action documentation update
- Handle `-f` for `mlc rm repo`
- Fix issue https://github.com/mlcommons/mlperf-automations/issues/263


Includes issue: https://github.com/mlcommons/mlcflow/issues/109