### PR TITLE
Enable the use of MLC logger when no automation object is being created

### DIFF
--- a/mlc/__init__.py
+++ b/mlc/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.1.0" 
 
 from .action import access
+from .logger import get_mlc_logger
 
-__all__ = ['access']
+__all__ = ['access', 'get_mlc_logger']

--- a/mlc/logger.py
+++ b/mlc/logger.py
@@ -40,3 +40,7 @@ def setup_logging(log_path = os.getcwd(),log_file = 'mlc-log.txt'):
         logger.propagate = False
 
 logger = logging.getLogger(__name__)
+
+def get_mlc_logger():
+    setup_logging(log_path=os.getcwd(),log_file='mlc-log.txt')
+    return logger


### PR DESCRIPTION
Usage:

```
>>> from mlc import get_mlc_logger
>>> logger = get_mlc_logger()
>>> logger.info("test info")
[2025-03-07 13:03:52,387 <stdin>:1 INFO] - test info
>>> logger.warning("test warning")
[2025-03-07 13:04:07,768 <stdin>:1 WARNING] - test warning
>>> logger.error("test warning")
[2025-03-07 13:04:13,313 <stdin>:1 ERROR] - test warning
```