### PR TITLE
Add connection to script help

### DIFF
--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -320,6 +320,9 @@ Main Script Meta:""")
         """
         return self.call_script_module_function("test", run_args)
 
+    def help(self, run_args):
+        # Internal function to call the help function in script automation module.py
+        return self.call_script_module_function("help", run_args)
 
     def list(self, args):
         """


### PR DESCRIPTION
Main idea of this PR is to set up a connection to script automation to display help regarding to individual scripts.

Example command(Dev Env):

```
python3 -m mlc.main help run script --tags=detect,os
```

Current output:

```
[2025-03-26 19:35:45,702 main.py:203 ERROR] - Function help is not supported
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/anandhu/testing/mlcflow/mlc/main.py", line 258, in <module>
    main()
  File "/home/anandhu/testing/mlcflow/mlc/main.py", line 204, in main
    raise Exception(f"""An error occurred {res}""")
Exception: An error occurred {'return': 1, 'error': 'Function help is not supported'}
```

Please note that the following error arise because the help function is not defined in `script automation module.py` in `mlperf-automations`