### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -7,6 +7,7 @@ import json
 import shutil
 from . import utils
 from .logger import logger
+from urllib.parse import urlparse
 
 class RepoAction(Action):
     """
@@ -85,7 +86,8 @@ class RepoAction(Action):
         if not os.path.exists(i_repo_path):
             #check if its an URL
             if utils.is_valid_url(i_repo_path):
-                if "github.com" in i_repo_path:
+                parsed = urlparse(i_repo_path)
+                if parsed.hostname == "github.com":
                     res = self.github_url_to_user_repo_format(i_repo_path)
                     if res['return'] > 0:
                         return res


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlcflow/security/code-scanning/11](https://github.com/mlcommons/mlcflow/security/code-scanning/11)

To safely determine if the incoming `i_repo_path` points to GitHub, we should use URL parsing rather than substring matching. We should use Python's standard library `urllib.parse.urlparse` to parse the URL and then check if the hostname is exactly 'github.com' (or optionally any subdomain of GitHub, if desired). This fix is to replace the unsafe substring check with a parsed-host equivalence check. The code change is in the conditional at line 88, within the `RepoAction.add` method, and may require importing `urlparse` from `urllib.parse` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
