### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-mlc-core-actions.yaml
+++ b/.github/workflows/test-mlc-core-actions.yaml
@@ -1,4 +1,6 @@
 name: MLC core actions test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlcflow/security/code-scanning/10](https://github.com/mlcommons/mlcflow/security/code-scanning/10)

To fix this problem, add a `permissions:` block at the root of the workflow file `.github/workflows/test-mlc-core-actions.yaml`. This block should specify the least privileges necessary for all jobs in the workflow, which, according to the visible steps, is only `contents: read`. The block should be placed just below the `name:` and before the `on:` key. This change will ensure that the GITHUB_TOKEN is granted only read access to repository contents, significantly reducing potential security exposure. No changes to jobs or steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
