### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,9 @@ on:
     types: [opened,closed,synchronize]
 permissions:
   contents: read
+  pull-requests: write
+  actions: read
+  statuses: write
 jobs:
   cla-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
-
+permissions:
+  contents: read
 jobs:
   cla-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/mlperf-inference-bert.yml
+++ b/.github/workflows/mlperf-inference-bert.yml
@@ -7,7 +7,8 @@ on:
       - '.github/workflows/test-mlperf-inference-bert-deepsparse-tf-onnxruntime-pytorch.yml'
       - '**'
       - '!**.md'
-
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/mlperf-inference-resnet50.yml
+++ b/.github/workflows/mlperf-inference-resnet50.yml
@@ -7,7 +7,8 @@ on:
       - '.github/workflows/mlperf-inference-resnet50.yml'
       - '**'
       - '!**.md'
-
+permissions:
+  contents: read
 jobs:
   build:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
       - dev
-
+permissions:
+  contents: read
 jobs:
-
   publish:
     name: Publish the site
     runs-on: ubuntu-latest

--- a/.github/workflows/test-mlc-docker-core.yml
+++ b/.github/workflows/test-mlc-docker-core.yml
@@ -7,7 +7,8 @@ on:
       - '.github/workflows/test-mlc-docker-core.yml'
       - '**'
       - '!**.md'
-
+permissions:
+  contents: read
 jobs:
   test_mlc_docker_core:
 

--- a/.github/workflows/test-mlc-podman.yml
+++ b/.github/workflows/test-mlc-podman.yml
@@ -8,6 +8,9 @@ on:
       - '**'
       - '!**.md'
 
+permissions:
+  contents: read
+
 jobs:
   test_mlc_docker_core:
 


### PR DESCRIPTION
Potential fix for [https://github.com/mlcommons/mlcflow/security/code-scanning/8](https://github.com/mlcommons/mlcflow/security/code-scanning/8)

The best way to fix this issue is to specify a minimal permissions block in this workflow file, restricting the `GITHUB_TOKEN` to only the capabilities required for the job(s). Since all steps in the workflow as shown relate to code checkout, environment setup, and testing, `contents: read` is usually sufficient.

You should add a block near the top-level of the file, immediately after the `name` and `on` fields, and before `jobs:`.  
If in future you require broader permissions for specific jobs, you can override these within the job definition.  
No changes to existing job steps or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
