### PR TITLE
Added support for mlc show repos

### DIFF
--- a/mlc/main.py
+++ b/mlc/main.py
@@ -129,7 +129,7 @@ log_levels = {'--verbose': logging.DEBUG, '--silent': logging.WARNING}
 def build_pre_parser():
     pre_parser = argparse.ArgumentParser(add_help=False)
     pre_parser.add_argument("action", nargs="?", help="Top-level action (run, build, help, etc.)")
-    pre_parser.add_argument("target", choices=['run', 'script', 'cache', 'repo'], nargs="?", help="Target (repo, script, cache, ...)")
+    pre_parser.add_argument("target", choices=['run', 'script', 'cache', 'repo', 'repos'], nargs="?", help="Target (repo, script, cache, ...)")
     pre_parser.add_argument("-h", "--help", action="store_true")
     return pre_parser
 
@@ -141,7 +141,7 @@ def build_parser(pre_args):
     # General commands
     for action in ['run', 'pull', 'test', 'add', 'show', 'list', 'find', 'search', 'rm', 'cp', 'mv', 'help']:
         p = subparsers.add_parser(action, add_help=False)
-        p.add_argument('target', choices=['repo', 'script', 'cache'])
+        p.add_argument('target', choices=['repo', 'repos', 'script', 'cache'])
         p.add_argument('details', nargs='?', help='Details or identifier (optional)')
         p.add_argument('extra', nargs=argparse.REMAINDER)
 
@@ -215,11 +215,11 @@ def main():
 
     Each target has a specific set of actions to tailor automation workflows, as shown below:
     
-    | Target  | Actions                                               |
-    |---------|-------------------------------------------------------|
+    | Target  | Actions                                                   |
+    |---------|-----------------------------------------------------------|
     | script  | run, find/search, rm, mv, cp, add, test, docker-run, show |
-    | cache   | find/search, rm, show                                 |
-    | repo    | pull, search, rm, list, find/search                   |
+    | cache   | find/search, rm, show                                     |
+    | repo    | pull, search, rm, list, find/search                       |
     
     Example:
       mlc run script detect-os
@@ -286,6 +286,12 @@ def main():
             print(help_text)
         sys.exit(0)
 
+    # show repos alias list repo
+    if args.command in ("show"):
+        args.command = "list"
+    if args.target == "repos":
+        args.target = "repo"
+        
     action = get_action(args.target, default_parent)
 
     if not action or not hasattr(action, args.command):

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -447,8 +447,8 @@ class RepoAction(Action):
     def list(self, run_args):
         """
     ####################################################################################################################
-    Target: Repo
-    Action: List
+    Target: Repo/Repos
+    Action: List/Show
     ####################################################################################################################
 
     The `list` action displays all registered MLC repositories along with their aliases and paths.


### PR DESCRIPTION
## ✅ PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### ✅ Testing & CI
- [ ] Have tested the changes in my local environment, else have properly conveyed in the PR description
- [ ] The change includes a GitHub Action to test the script(if it is possible to be added).
- [ ] No existing GitHub Actions are failing because of this change.

### 📚 Documentation
- [ ] README or help docs are updated for new features or changes.
- [ ] CLI help messages are meaningful and complete.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed.

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed.
- [ ] Paths, shell commands, and environment handling are safe and portable.

### 🙌 Contribution Hygiene
- [ ] PR title and description are concise and clearly state the purpose of the change.
- [ ] Related issues (if any) are properly referenced using `Fixes #` or `Closes #`.
- [ ] All reviewer feedback has been addressed.

Fix for #188 .

Logs:
```shell
(mlcflow) sujith@ideapad-g3:~$ mlc show repo
[2025-11-08 18:37:07,917 repo_action.py:467 INFO] - Listing all repositories.

Repositories:
-------------
- Alias: local
  Path:  /home/sujith/MLC/repos/local

- Alias: llm-gate-exam-evaluation
  Path:  /home/sujith/MLC/repos/llm-gate-exam-evaluation

- Alias: mlcommons@mlperf-automations
  Path:  /home/sujith/MLC/repos/mlcommons@mlperf-automations

-------------
[2025-11-08 18:37:07,918 repo_action.py:474 INFO] - Repository listing ended
(mlcflow) sujith@ideapad-g3:~$ mlc show repos
[2025-11-08 18:37:24,427 repo_action.py:467 INFO] - Listing all repositories.

Repositories:
-------------
- Alias: local
  Path:  /home/sujith/MLC/repos/local

- Alias: llm-gate-exam-evaluation
  Path:  /home/sujith/MLC/repos/llm-gate-exam-evaluation

- Alias: mlcommons@mlperf-automations
  Path:  /home/sujith/MLC/repos/mlcommons@mlperf-automations

-------------
[2025-11-08 18:37:24,427 repo_action.py:474 INFO] - Repository listing ended
(mlcflow) sujith@ideapad-g3:~$ 
```

