### PR TITLE
Add file locking for index operations

### DIFF
--- a/mlc/index.py
+++ b/mlc/index.py
@@ -4,6 +4,7 @@ import json
 import yaml
 from .repo import Repo
 from datetime import datetime
+from filelock import FileLock, Timeout
 
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -54,42 +55,74 @@ class Index:
         """
         Load stored mtimes to check for changes in scripts.
         """
-        if os.path.exists(self.modified_times_file):
-            try:
-                # logger.info(f"Loading modified times from {self.modified_times_file}")
-                with open(self.modified_times_file, "r") as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, IOError) as e:
-                logger.warning(f"Failed to load modified times: {e}")
-                return {}
-        return {}
+        lock_file = self.modified_times_file + ".lock"
+        try:
+            with FileLock(lock_file, timeout=30):
+                # logger.debug(f"Lock acquired at {lock_file} for Loading Modified Times")
+
+                if os.path.exists(self.modified_times_file):
+                    # logger.info(f"Loading modified times from {self.modified_times_file}")
+                    with open(self.modified_times_file, "r") as f:
+                        return json.load(f)
+                else:
+                    return {}
+                
+        except Timeout:
+            logger.warning(f"Timeout acquiring lock {lock_file}")
+            return {}
+
+        except Exception as e:
+            logger.error(f"Error acquiring lock {lock_file}: {e}")
+            return {}
+
 
     def _save_modified_times(self):
         """
         Save updated mtimes in modified_times json file.
         """
-        #logger.debug(f"Saving modified times to {self.modified_times_file}")
-        with open(self.modified_times_file, "w") as f:
-            json.dump(self.modified_times, f, indent=4)
+        lock_file = self.modified_times_file + ".lock"
+        try:
+            with FileLock(lock_file, timeout=30):
+                logger.debug(f"Lock acquired at {lock_file} for Saving Modified Times")
+
+                #logger.debug(f"Saving modified times to {self.modified_times_file}")
+                with open(self.modified_times_file, "w") as f:
+                    json.dump(self.modified_times, f, indent=4)
+        
+        except Timeout:
+            logger.warning(f"Timeout acquiring lock {lock_file}, skipping modified times save")
+
+        except Exception as e:
+            logger.error(f"Error saving modified times: {e}")
 
     def _load_existing_index(self):
         """
         Load previously saved index to allow incremental updates.
         """
         for folder_type, file_path in self.index_files.items():
-            if os.path.exists(file_path):
-                try:
-                    # logger.info(f"Loading existing index for {folder_type}")
-                    with open(file_path, "r") as f:
-                        self.indices[folder_type] = json.load(f)
-                    # Convert repo dicts back into Repo objects
-                    for item in self.indices[folder_type]:
-                        if isinstance(item.get("repo"), dict):
-                            item["repo"] = Repo(**item["repo"])
+            lock_file = file_path + ".lock"
+            try:
+                with FileLock(lock_file, timeout=30):
+                    # logger.debug(f"Lock acquired at {lock_file} for Loading Index for {folder_type}")
 
-                except (json.JSONDecodeError, IOError, KeyError, TypeError) as e:
-                    logger.warning(f"Failed to load index for {folder_type}: {e}")
-                    pass   # fall back to empty index
+                    if os.path.exists(file_path):
+                        # logger.info(f"Loading existing index for {folder_type}")
+                        with open(file_path, "r") as f:
+                            self.indices[folder_type] = json.load(f)
+                        # Convert repo dicts back into Repo objects
+                        for item in self.indices[folder_type]:
+                            if isinstance(item.get("repo"), dict):
+                                item["repo"] = Repo(**item["repo"])
+                    else:
+                        self.indices[folder_type] = []
+            
+            except Timeout:
+                logger.error(f"Timeout acquiring lock {lock_file}")
+                self.indices[folder_type] = []
+
+            except (json.JSONDecodeError, IOError, KeyError, TypeError) as e:
+                logger.warning(f"Failed to load index for {folder_type}: {e}")
+                self.indices[folder_type] = []   # fall back to empty index
 
     def add(self, meta, folder_type, path, repo):
         if not repo:
@@ -353,10 +386,18 @@ class Index:
         #logger.info(self.indices)
         for folder_type, index_data in self.indices.items():
             output_file = self.index_files[folder_type]
+            lock_file = output_file + ".lock"
             try:
-                with open(output_file, "w") as f:
-                    json.dump(index_data, f, indent=4, cls=CustomJSONEncoder)
-                #logger.debug(f"Shared index for {folder_type} saved to {output_file}.")
+                with FileLock(lock_file, timeout=30):
+                    logger.debug(f"Lock acquired at {lock_file} for Saving Index for {folder_type}")
+
+                    with open(output_file, "w") as f:
+                        json.dump(index_data, f, indent=4, cls=CustomJSONEncoder)
+                    #logger.debug(f"Shared index for {folder_type} saved to {output_file}.")
+            
+            except Timeout:
+                logger.error(f"Timeout acquiring lock {lock_file}")
+
             except Exception as e:
                 logger.error(f"Error saving shared index for {folder_type}: {e}")
 

--- a/mlc/index.py
+++ b/mlc/index.py
@@ -407,7 +407,7 @@ class Index:
             lock_file = output_file + ".lock"
             try:
                 with self._file_lock_with_incremental_timeout(lock_file):
-                    logger.debug(f"Lock acquired at {lock_file} for Saving Index for {folder_type}")
+                    #logger.debug(f"Lock acquired at {lock_file} for Saving Index for {folder_type}")
 
                     with open(output_file, "w") as f:
                         json.dump(index_data, f, indent=4, cls=CustomJSONEncoder)

--- a/mlc/index.py
+++ b/mlc/index.py
@@ -4,6 +4,7 @@ import json
 import yaml
 from .repo import Repo
 from datetime import datetime
+from contextlib import contextmanager
 from filelock import FileLock, Timeout
 
 class CustomJSONEncoder(json.JSONEncoder):
@@ -57,7 +58,7 @@ class Index:
         """
         lock_file = self.modified_times_file + ".lock"
         try:
-            with FileLock(lock_file, timeout=30):
+            with self._file_lock_with_incremental_timeout(lock_file):
                 # logger.debug(f"Lock acquired at {lock_file} for Loading Modified Times")
 
                 if os.path.exists(self.modified_times_file):
@@ -75,6 +76,23 @@ class Index:
             logger.error(f"Error acquiring lock {lock_file}: {e}")
             return {}
 
+    @contextmanager
+    def _file_lock_with_incremental_timeout(self, lock_file, timeout_seconds=60):
+        """
+        Acquire a file lock by waiting up to a minute, then retrying once if it times out.
+        """
+        try:
+            with FileLock(lock_file, timeout=timeout_seconds):
+                yield # Control goes to the caller's 'with' block while the file lock is held
+                return
+        except Timeout:
+            logger.warning(
+                f"Timeout acquiring lock {lock_file} after {int(timeout_seconds)}s. "
+                f"Retrying once for another {int(timeout_seconds)}s..."
+            )
+
+        with FileLock(lock_file, timeout=timeout_seconds):
+            yield
 
     def _save_modified_times(self):
         """
@@ -82,8 +100,8 @@ class Index:
         """
         lock_file = self.modified_times_file + ".lock"
         try:
-            with FileLock(lock_file, timeout=30):
-                logger.debug(f"Lock acquired at {lock_file} for Saving Modified Times")
+            with self._file_lock_with_incremental_timeout(lock_file):
+                # logger.debug(f"Lock acquired at {lock_file} for Saving Modified Times")
 
                 #logger.debug(f"Saving modified times to {self.modified_times_file}")
                 with open(self.modified_times_file, "w") as f:
@@ -102,7 +120,7 @@ class Index:
         for folder_type, file_path in self.index_files.items():
             lock_file = file_path + ".lock"
             try:
-                with FileLock(lock_file, timeout=30):
+                with self._file_lock_with_incremental_timeout(lock_file):
                     # logger.debug(f"Lock acquired at {lock_file} for Loading Index for {folder_type}")
 
                     if os.path.exists(file_path):
@@ -388,7 +406,7 @@ class Index:
             output_file = self.index_files[folder_type]
             lock_file = output_file + ".lock"
             try:
-                with FileLock(lock_file, timeout=30):
+                with self._file_lock_with_incremental_timeout(lock_file):
                     logger.debug(f"Lock acquired at {lock_file} for Saving Index for {folder_type}")
 
                     with open(output_file, "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "requests",
     "pyyaml",
     "giturlparse",
-    "colorama"
+    "colorama",
+    "filelock"
 ]
 
 [project.urls]


### PR DESCRIPTION
Added file locking for index operations to prevent race condition.
Test Logs:
```bash
(mlc) sujith@ideapadG3:~$ python test_file_no_lock.py
[2026-03-04 20:22:29,811 index.py       :  36 DEBUG] - Repos path for Index: /home/sujith/MLC/repos
[2026-03-04 20:22:29,812 index.py       :  67 DEBUG] - [P2] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,812 index.py       :  36 DEBUG] - Repos path for Index: /home/sujith/MLC/repos
[2026-03-04 20:22:29,812 index.py       :  71 DEBUG] - +++++++++ [P2]|[176797]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.009s +++++++++++++
[2026-03-04 20:22:29,812 index.py       :  67 DEBUG] - [P0] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,813 index.py       :  45 DEBUG] - [P2] LOADED modified times loaded .......
[2026-03-04 20:22:29,816 index.py       :  67 DEBUG] - [P2] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,816 index.py       :  71 DEBUG] - +++++++++ [P2]|[176797]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.013s +++++++++++++
[2026-03-04 20:22:29,816 index.py       :  36 DEBUG] - Repos path for Index: /home/sujith/MLC/repos
[2026-03-04 20:22:29,816 index.py       :  67 DEBUG] - [P1] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,824 main.py        : 122 INFO ] - Item path: /home/sujith/MLC/repos/mlcommons@mlperf-automations/script/detect-os
[2026-03-04 20:22:29,863 index.py       :  71 DEBUG] - +++++++++ [P0]|[176793]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.059s +++++++++++++
[2026-03-04 20:22:29,865 index.py       :  45 DEBUG] - [P0] LOADED modified times loaded .......
[2026-03-04 20:22:29,867 index.py       :  71 DEBUG] - +++++++++ [P1]|[176796]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.059s +++++++++++++
[2026-03-04 20:22:29,868 index.py       :  67 DEBUG] - [P0] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,868 index.py       :  71 DEBUG] - +++++++++ [P0]|[176793]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.064s +++++++++++++
[2026-03-04 20:22:29,868 index.py       :  45 DEBUG] - [P1] LOADED modified times loaded .......
[2026-03-04 20:22:29,870 index.py       :  67 DEBUG] - [P1] Waiting to acquire lock Modified Times lock
[2026-03-04 20:22:29,871 index.py       :  71 DEBUG] - +++++++++ [P1]|[176796]  Lock acquired at /home/sujith/MLC/repos/modified_times.json.lock for Loading Modified Times after waiting 0.063s +++++++++++++
[2026-03-04 20:22:29,876 main.py        : 122 INFO ] - Item path: /home/sujith/MLC/repos/mlcommons@mlperf-automations/script/detect-os
[2026-03-04 20:22:29,880 main.py        : 122 INFO ] - Item path: /home/sujith/MLC/repos/mlcommons@mlperf-automations/script/detect-os
(mlc) sujith@ideapadG3:~$ 
```

## ✅ PR Checklist

- [ ] Target branch is `dev`

📌 Note: PRs must be raised against `dev`. Do not commit directly to `main`.

### ✅ Testing & CI
- [ ] Have tested the changes in my local environment, else have properly conveyed in the PR description
- [ ] The change includes a GitHub Action to test the script(if it is possible to be added).
- [ ] No existing GitHub Actions are failing because of this change.

### 📚 Documentation
- [ ] README or help docs are updated for new features or changes.
- [ ] CLI help messages are meaningful and complete.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed.

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed.
- [ ] Paths, shell commands, and environment handling are safe and portable.

### 🙌 Contribution Hygiene
- [ ] PR title and description are concise and clearly state the purpose of the change.
- [ ] Related issues (if any) are properly referenced using `Fixes #` or `Closes #`.
- [ ] All reviewer feedback has been addressed.