### PR TITLE
Add pip-package script-content discovery (Phase 1 prototype)

### DIFF
--- a/mlc/action.py
+++ b/mlc/action.py
@@ -589,6 +589,7 @@ class Action:
                         force_remove = True
 
         results = res['list']
+        removed_paths = []
 
         for result in results:
             item_path = result.path
@@ -615,10 +616,21 @@ class Action:
                     f"{target_name} item: {item_path} has been successfully removed")
 
             self.get_index().rm(item_meta, target_name, item_path)
+            removed_paths.append(item_path)
+
+        if not removed_paths:
+            return {
+                "return": 0,
+                "warnings": [{"code": WarningCode.EMPTY_TARGET.code,
+                              "description": f"No {target_name} item was actually removed "
+                              f"(skipped: read-only pip-sourced repo, or declined confirmation)"}],
+                "message": "No items were removed",
+            }
 
         return {
             "return": 0,
-            "message": f"Item {item_path} successfully removed",
+            "message": f"Item {removed_paths[-1]} successfully removed",
+            "removed": removed_paths,
         }
 
     def save_new_meta(self, i, item_id, item_name,
@@ -813,15 +825,21 @@ class Action:
                         'return': 1, 'error': f"""Current directory is not inside a registered MLC repo and so using ".:" is not valid"""}
                 target_repo_name = os.path.basename(self.current_repo_path)
 
-            # Match by alias first - the on-disk directory basename doesn't
+            # Match by alias first, across ALL repos, before ever falling
+            # back to basename - the on-disk directory basename doesn't
             # always match the repo's alias (e.g. a pip-sourced repo's
             # site-packages directory "mlc_scripts_content" vs its
-            # distribution-name alias "mlc-scripts"). Fall back to basename
-            # matching for repos with no alias set.
+            # distribution-name alias "mlc-scripts"). Checking both in a
+            # single predicate would let an unrelated repo's basename match
+            # shadow the correct alias match depending on list order; doing
+            # alias as its own full pass first avoids that ambiguity.
             target_repo = next(
-                (k for k in self.repos
-                 if k.meta.get('alias') == target_repo_name
-                 or os.path.basename(k.path) == target_repo_name), None)
+                (k for k in self.repos if k.meta.get('alias') == target_repo_name),
+                None)
+            if target_repo is None:
+                target_repo = next(
+                    (k for k in self.repos
+                     if os.path.basename(k.path) == target_repo_name), None)
 
             if target_repo is None:
                 return {'return': 1, 'error': f"""The target repo {target_repo_name} is not registered in MLC. Either register in MLC by cloning from Git through command `mlc pull repo` or create repo using `mlc add repo` command and try to rerun the command again"""}

--- a/mlc/action.py
+++ b/mlc/action.py
@@ -5,6 +5,8 @@ import yaml
 import logging
 import re
 import shutil
+import hashlib
+import importlib.metadata as importlib_metadata
 from pathlib import Path
 
 from .logger import logger, setup_logging
@@ -14,6 +16,147 @@ from .index import Index
 from .repo import Repo
 from .item import Item
 from .error_codes import WarningCode
+
+# Entry-point group that pip-installable script-content packages advertise
+# themselves under (e.g. a package shipping the mlperf-automations script/
+# tree, or a fork of it under a different distribution name).
+SCRIPT_PACKAGE_ENTRY_POINT_GROUP = "mlc.script_packages"
+
+
+def _get_script_package_entry_points():
+    """
+    Version-compatible retrieval of entry points in
+    SCRIPT_PACKAGE_ENTRY_POINT_GROUP. Python 3.10+ supports
+    entry_points(group=...) directly; 3.8/3.9 only support the argument-less
+    entry_points(), which returns a plain dict (or dict-like
+    SelectableGroups) keyed by group name.
+    """
+    try:
+        return list(importlib_metadata.entry_points(
+            group=SCRIPT_PACKAGE_ENTRY_POINT_GROUP))
+    except TypeError:
+        # Python < 3.10: entry_points() takes no 'group' kwarg.
+        try:
+            all_eps = importlib_metadata.entry_points()
+            return list(all_eps.get(SCRIPT_PACKAGE_ENTRY_POINT_GROUP, []))
+        except Exception as e:
+            logger.debug(
+                f"Could not enumerate '{SCRIPT_PACKAGE_ENTRY_POINT_GROUP}' "
+                f"entry points on this Python version: {e}")
+            return []
+    except Exception as e:
+        logger.debug(
+            f"Could not enumerate '{SCRIPT_PACKAGE_ENTRY_POINT_GROUP}' entry points: {e}")
+        return []
+
+
+def _pip_repo_cache_path(repos_path):
+    return os.path.join(repos_path, "package_repos_cache.json")
+
+
+def _load_pip_repo_cache(repos_path):
+    cache_file = _pip_repo_cache_path(repos_path)
+    if not os.path.isfile(cache_file):
+        return {}
+    try:
+        with open(cache_file, "r") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_pip_repo_cache(repos_path, cache):
+    try:
+        os.makedirs(repos_path, exist_ok=True)
+        with open(_pip_repo_cache_path(repos_path), "w") as f:
+            json.dump(cache, f, indent=2)
+    except OSError as e:
+        logger.debug(f"Could not save pip script package cache: {e}")
+
+
+def discover_pip_script_repos(repos_path):
+    """
+    Discover script-content repos advertised by installed pip packages via
+    the SCRIPT_PACKAGE_ENTRY_POINT_GROUP entry-point group. Returns a list
+    of Repo objects, one per distinct installed *distribution*.
+
+    Deliberately aliases each repo by the entry point's owning distribution
+    name (`ep.dist.name`), NOT the self-chosen entry-point name (`ep.name`).
+    PyPI enforces distribution-name uniqueness the same way GitHub enforces
+    owner/repo uniqueness, so this is what lets a fork of a script-content
+    package coexist with the original even if both declare the same
+    entry-point name and even if the fork copied script uids verbatim.
+
+    entry_points() itself is a fast, local, no-network scan of installed
+    *.dist-info/entry_points.txt files (the same mechanism `pip list` relies
+    on) and is called every run - it's cheap. What's NOT free is `.load()`,
+    which actually imports the resolver module; that's cached across runs in
+    <repos_path>/package_repos_cache.json keyed by distribution name, so an
+    already-known package's content dir is reused directly without
+    re-importing anything.
+
+    Distributions that disappear (uninstalled) are simply left out of the
+    returned list - Index.build_index()'s existing deleted-item detection
+    (comparing each run's indexed files against modified_times.json) already
+    prunes their content automatically, so no explicit
+    Index.remove_repo_from_index() call is needed here.
+    """
+    cache = _load_pip_repo_cache(repos_path)
+    updated_cache = {}
+    discovered = {}
+    cache_changed = False
+
+    for ep in _get_script_package_entry_points():
+        dist = getattr(ep, 'dist', None)
+        dist_name = dist.name if dist is not None else ep.name
+        if dist_name in discovered:
+            # Same distribution declaring more than one entry point in this
+            # group - first one found wins, it's still the same repo.
+            continue
+
+        content_dir = cache.get(dist_name)
+        if content_dir and os.path.isdir(content_dir):
+            # Already known from a previous run - reuse it, skip the
+            # (import-triggering) ep.load() call entirely.
+            updated_cache[dist_name] = content_dir
+        else:
+            try:
+                module = ep.load()
+                content_dir = os.path.dirname(os.path.abspath(module.__file__))
+            except Exception as e:
+                logger.warning(
+                    f"Skipping script package entry point '{ep.name}' from "
+                    f"distribution '{dist_name}': failed to load ({e})")
+                continue
+
+            if not os.path.isdir(content_dir):
+                logger.warning(
+                    f"Script package '{dist_name}' entry point resolved to "
+                    f"a non-existent directory: {content_dir}. Skipping.")
+                continue
+
+            updated_cache[dist_name] = content_dir
+            cache_changed = True
+            logger.info(
+                f"Discovered new script package '{dist_name}' at {content_dir}")
+
+        uid = hashlib.md5(dist_name.encode('utf-8')).hexdigest()[:16]
+        discovered[dist_name] = Repo(path=updated_cache[dist_name], meta={
+            'alias': dist_name,
+            'uid': uid,
+            'source': 'pip',
+        })
+
+    if set(cache.keys()) - set(updated_cache.keys()):
+        # one or more previously-known packages disappeared (uninstalled)
+        cache_changed = True
+
+    if cache_changed:
+        _save_pip_repo_cache(repos_path, updated_cache)
+
+    return list(discovered.values())
+
 
 # Base class for actions
 
@@ -26,6 +169,18 @@ class Action:
     local_repo = None
     current_repo_path = None
     repos = []  # list of Repo objects
+
+    @staticmethod
+    def _is_pip_sourced_repo(repo_obj):
+        """
+        True if repo_obj (a Repo instance) was discovered from an installed
+        pip package rather than a git-cloned/registered repo. Its files live
+        inside the Python environment's site-packages, not ~/MLC/repos, and
+        must not be mutated by mlc add/cp/mv/rm - that would corrupt the
+        installed package outside of pip's own bookkeeping.
+        """
+        return bool(repo_obj) and getattr(
+            repo_obj, 'meta', {}).get('source') == 'pip'
 
     # Main access function to simulate a Python interface for CLI
     def access(self, options):
@@ -248,7 +403,12 @@ class Action:
         if not os.path.exists(self.local_cache_path):
             os.makedirs(self.local_cache_path, exist_ok=True)
 
-        self.repos = self.load_repos_and_meta()
+        # Pip-sourced script-content repos are prepended (processed first),
+        # so git-cloned repos loaded below are processed last and win any
+        # script-uid conflicts - pip is a second, lower-trust source for now
+        # (see mlcflow-pip-script-packages-proposal.pptx, Phase 1).
+        self.repos = discover_pip_script_repos(
+            self.repos_path) + self.load_repos_and_meta()
         # logger.info(f"In Action class: {self.repos_path}")
         self._index = None
 
@@ -306,6 +466,10 @@ class Action:
 
         # Determine paths and metadata format
         repo = res["list"][0]
+        if self._is_pip_sourced_repo(repo):
+            return {
+                'return': 1,
+                'error': f"""Repo '{repo.meta.get('alias')}' is sourced from an installed pip package (read-only) - cannot add items to it. Use a git-cloned repo or the local repo instead."""}
         repo_path = repo.path
 
         target_name = i.get('target_name', self.action_type)
@@ -429,6 +593,12 @@ class Action:
         for result in results:
             item_path = result.path
             item_meta = result.meta
+
+            if self._is_pip_sourced_repo(getattr(result, 'repo', None)):
+                logger.warning(
+                    f"Skipping removal of {item_path}: sourced from an "
+                    f"installed pip package (read-only), not a git-cloned repo.")
+                continue
 
             if os.path.exists(item_path):
                 if force_remove == True:
@@ -642,19 +812,30 @@ class Action:
                     return {
                         'return': 1, 'error': f"""Current directory is not inside a registered MLC repo and so using ".:" is not valid"""}
                 target_repo_name = os.path.basename(self.current_repo_path)
-            else:
-                if not any(os.path.basename(repodata.path) ==
-                           target_repo_name for repodata in self.repos):
-                    return {'return': 1, 'error': f"""The target repo {target_repo} is not registered in MLC. Either register in MLC by cloning from Git through command `mlc pull repo` or create repo using `mlc add repo` command and try to rerun the command again"""}
-            target_repo_path = os.path.join(self.repos_path, target_repo_name)
+
+            # Match by alias first - the on-disk directory basename doesn't
+            # always match the repo's alias (e.g. a pip-sourced repo's
+            # site-packages directory "mlc_scripts_content" vs its
+            # distribution-name alias "mlc-scripts"). Fall back to basename
+            # matching for repos with no alias set.
             target_repo = next(
-                (k for k in self.repos if os.path.basename(
-                    k.path) == target_repo_name), None)
+                (k for k in self.repos
+                 if k.meta.get('alias') == target_repo_name
+                 or os.path.basename(k.path) == target_repo_name), None)
+
+            if target_repo is None:
+                return {'return': 1, 'error': f"""The target repo {target_repo_name} is not registered in MLC. Either register in MLC by cloning from Git through command `mlc pull repo` or create repo using `mlc add repo` command and try to rerun the command again"""}
+            target_repo_path = target_repo.path
             target_item_name = target_split[1].strip()
         else:
             target_repo = result.repo
             target_repo_path = result.repo.path
             target_item_name = target_split[0].strip()
+
+        if self._is_pip_sourced_repo(target_repo):
+            return {
+                'return': 1,
+                'error': f"""Target repo '{getattr(target_repo, 'meta', {}).get('alias')}' is sourced from an installed pip package (read-only) - cannot copy/move items into it."""}
 
         target_item_path = os.path.join(
             target_repo_path, action_target, target_item_name)

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -709,6 +709,11 @@ class RepoAction(Action):
             repo = list_repos[0]
             repo_path = repo.path
 
+            if Action._is_pip_sourced_repo(repo):
+                return {
+                    'return': 1,
+                    'error': f"""Repo '{repo.meta.get('alias')}' is sourced from an installed pip package, not a git clone - there is nothing to remove from ~/MLC/repos for it, and its files must not be deleted directly (that would corrupt the pip installation outside of pip's own bookkeeping). Run `pip uninstall {repo.meta.get('alias')}` instead; it will then stop being discovered automatically."""}
+
         else:
             repo = run_args['repo']
             if os.path.exists(repo):

--- a/tests/test_pip_script_discovery.py
+++ b/tests/test_pip_script_discovery.py
@@ -104,7 +104,7 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_entry_points_enumeration_failure_does_not_crash(self):
         with patch.object(_mlc_action.importlib_metadata, "entry_points",
-                           side_effect=RuntimeError("boom")):
+                          side_effect=RuntimeError("boom")):
             repos = discover_pip_script_repos(self.repos_path)
         self.assertEqual(repos, [])
 
@@ -114,8 +114,12 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         # which returns a plain dict (or dict-like SelectableGroups) keyed
         # by group name.
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
-        other_group_ep = _FakeEntryPoint("unrelated", "unrelated-dist", "/nonexistent")
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
+        other_group_ep = _FakeEntryPoint(
+            "unrelated", "unrelated-dist", "/nonexistent")
 
         def fake_entry_points(*args, **kwargs):
             if "group" in kwargs:
@@ -127,7 +131,7 @@ class PipScriptDiscoveryTest(unittest.TestCase):
             }
 
         with patch.object(_mlc_action.importlib_metadata, "entry_points",
-                           side_effect=fake_entry_points):
+                          side_effect=fake_entry_points):
             repos = discover_pip_script_repos(self.repos_path)
 
         self.assertEqual(len(repos), 1)
@@ -142,7 +146,7 @@ class PipScriptDiscoveryTest(unittest.TestCase):
             return {"some.other.group": []}
 
         with patch.object(_mlc_action.importlib_metadata, "entry_points",
-                           side_effect=fake_entry_points):
+                          side_effect=fake_entry_points):
             repos = discover_pip_script_repos(self.repos_path)
         self.assertEqual(repos, [])
 
@@ -150,7 +154,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_basic_discovery_adds_repo_and_makes_script_searchable(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
 
         with self._patch_entry_points([ep]):
             action = self._new_action()
@@ -170,12 +177,18 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_cache_skips_reload_on_second_run_with_no_changes(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep1 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep1 = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep1]):
             discover_pip_script_repos(self.repos_path)
         self.assertEqual(ep1.load_call_count, 1)
 
-        ep2 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep2 = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep2]):
             repos = discover_pip_script_repos(self.repos_path)
 
@@ -186,13 +199,19 @@ class PipScriptDiscoveryTest(unittest.TestCase):
     def test_cache_file_written_only_when_something_changes(self):
         cache_file = os.path.join(self.repos_path, "package_repos_cache.json")
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep1 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep1 = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep1]):
             discover_pip_script_repos(self.repos_path)
         self.assertTrue(os.path.exists(cache_file))
         mtime_after_first = os.path.getmtime(cache_file)
 
-        ep2 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep2 = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep2]):
             discover_pip_script_repos(self.repos_path)
         self.assertEqual(os.path.getmtime(cache_file), mtime_after_first)
@@ -204,7 +223,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
             f.write("{not valid json")
 
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             repos = discover_pip_script_repos(self.repos_path)
 
@@ -215,7 +237,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_uninstalled_package_disappears_on_next_discovery(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             repos = discover_pip_script_repos(self.repos_path)
         self.assertEqual(len(repos), 1)
@@ -226,7 +251,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_uninstalled_package_scripts_removed_from_index(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             action = self._new_action()
         res = action.search({"target_name": "script", "tags": "detect-widget"})
@@ -234,12 +262,14 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
         with self._patch_entry_points([]):
             action2 = self._new_action()
-        res2 = action2.search({"target_name": "script", "tags": "detect-widget"})
+        res2 = action2.search(
+            {"target_name": "script", "tags": "detect-widget"})
         self.assertEqual(len(res2["list"]), 0)
 
     # ---- 5.1 fork disambiguation (core design point) -----------------------
 
-    def test_fork_with_same_entry_point_name_different_distribution_coexist(self):
+    def test_fork_with_same_entry_point_name_different_distribution_coexist(
+            self):
         official_dir = os.path.join(self.temp_dir.name, "official_pkg")
         fork_dir = os.path.join(self.temp_dir.name, "fork_pkg")
         _write_script(official_dir, "detect-widget", "a" * 16)
@@ -260,7 +290,9 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
         pip_aliases = sorted(
             r.meta["alias"] for r in action.repos if r.meta.get("source") == "pip")
-        self.assertEqual(pip_aliases, ["anandhu-mlc-scripts-fork", "mlc-scripts"])
+        self.assertEqual(
+            pip_aliases, [
+                "anandhu-mlc-scripts-fork", "mlc-scripts"])
 
         res_official = action.search(
             {"target_name": "script", "tags": "detect-widget"})
@@ -273,7 +305,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_script_in_pip_repo_resolvable_as_dep_of_git_repo_script(self):
         _write_script(self.content_dir, "get-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
 
         with self._patch_entry_points([ep]):
             action = self._new_action()
@@ -301,13 +336,18 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         dep_lookup = action2.search(
             {"target_name": "script", "tags": "get-widget"})
         self.assertEqual(len(dep_lookup["list"]), 1)
-        self.assertTrue(dep_lookup["list"][0].path.startswith(self.content_dir))
+        self.assertTrue(
+            dep_lookup["list"][0].path.startswith(
+                self.content_dir))
 
     # ---- 9.1 broken package doesn't take down discovery for others --------
 
     def test_broken_entry_point_is_skipped_others_still_discovered(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        good_ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        good_ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         broken_ep = _FakeEntryPoint(
             "broken-pkg", "broken-dist", "/nonexistent",
             load_error=ImportError("simulated broken package"))
@@ -319,7 +359,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         self.assertEqual(repos[0].meta["alias"], "mlc-scripts")
 
     def test_entry_point_resolving_to_missing_directory_is_skipped(self):
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", "/nonexistent/path")
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            "/nonexistent/path")
         with self._patch_entry_points([ep]):
             repos = discover_pip_script_repos(self.repos_path)
         self.assertEqual(repos, [])
@@ -328,7 +371,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_add_script_refused_for_pip_sourced_repo(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             action = self._new_action()
 
@@ -342,9 +388,13 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         self.assertFalse(
             os.path.exists(os.path.join(self.content_dir, "script", "new-script-1")))
 
-    def test_rm_script_refused_for_pip_sourced_repo_and_reports_nothing_removed(self):
+    def test_rm_script_refused_for_pip_sourced_repo_and_reports_nothing_removed(
+            self):
         script_dir = _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             action = self._new_action()
 
@@ -362,7 +412,10 @@ class PipScriptDiscoveryTest(unittest.TestCase):
 
     def test_rm_repo_refused_for_pip_sourced_repo(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             action = self._new_action()
 
@@ -372,14 +425,18 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         self.assertIn("pip uninstall", res["error"])
         self.assertTrue(os.path.isdir(self.content_dir))
 
-    def test_cp_script_into_pip_sourced_repo_referenced_by_alias_is_refused(self):
+    def test_cp_script_into_pip_sourced_repo_referenced_by_alias_is_refused(
+            self):
         # Regression test: the pip repo's on-disk directory basename
         # ("content_pkg", a tempdir name) never matches its alias
         # ("mlc-scripts", the distribution name) - cp()'s target-repo lookup
         # used to match by basename only and would crash with a NameError
         # instead of returning a clean refusal for exactly this mismatch.
         _write_script(self.content_dir, "detect-widget", "a" * 16)
-        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        ep = _FakeEntryPoint(
+            "mlperf-automations",
+            "mlc-scripts",
+            self.content_dir)
         with self._patch_entry_points([ep]):
             action = self._new_action()
 

--- a/tests/test_pip_script_discovery.py
+++ b/tests/test_pip_script_discovery.py
@@ -1,0 +1,342 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import mlc.action as _mlc_action
+from mlc.action import (
+    Action,
+    discover_pip_script_repos,
+    SCRIPT_PACKAGE_ENTRY_POINT_GROUP,
+)
+
+
+class _FakeDist:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeModule:
+    def __init__(self, content_dir):
+        self.__file__ = os.path.join(content_dir, "__init__.py")
+
+
+class _FakeEntryPoint:
+    """Stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name, dist_name, content_dir, load_error=None):
+        self.name = name
+        self.dist = _FakeDist(dist_name) if dist_name is not None else None
+        self._content_dir = content_dir
+        self._load_error = load_error
+        self.load_call_count = 0
+
+    def load(self):
+        self.load_call_count += 1
+        if self._load_error:
+            raise self._load_error
+        return _FakeModule(self._content_dir)
+
+
+def _write_script(content_dir, alias, uid, tags=None, deps=None):
+    script_dir = os.path.join(content_dir, "script", alias)
+    os.makedirs(script_dir, exist_ok=True)
+    meta = {
+        "alias": alias,
+        "uid": uid,
+        "automation_alias": "script",
+        "automation_uid": "5b4e0237da074764",
+        "tags": tags or [alias],
+    }
+    if deps:
+        meta["deps"] = deps
+    import yaml
+    with open(os.path.join(script_dir, "meta.yaml"), "w") as f:
+        yaml.safe_dump(meta, f)
+    with open(os.path.join(script_dir, "customize.py"), "w") as f:
+        f.write("def preprocess(i):\n    return {'return': 0}\n")
+    return script_dir
+
+
+class PipScriptDiscoveryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.previous_cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.previous_cwd)
+        os.chdir(self.temp_dir.name)
+
+        self.previous_mlc_repos = os.environ.get("MLC_REPOS")
+        self.addCleanup(self._restore_env)
+        self.repos_path = os.path.join(self.temp_dir.name, "repos")
+        os.environ["MLC_REPOS"] = self.repos_path
+
+        self.content_dir = os.path.join(self.temp_dir.name, "content_pkg")
+        os.makedirs(self.content_dir, exist_ok=True)
+
+    def _restore_env(self):
+        if self.previous_mlc_repos is None:
+            os.environ.pop("MLC_REPOS", None)
+        else:
+            os.environ["MLC_REPOS"] = self.previous_mlc_repos
+
+    def _new_action(self):
+        a = Action()
+        a.parent = None
+        return a
+
+    def _patch_entry_points(self, entry_points):
+        return patch.object(
+            _mlc_action.importlib_metadata, "entry_points",
+            return_value=entry_points)
+
+    # ---- 2.1 no-op safety ------------------------------------------------
+
+    def test_no_entry_points_is_complete_noop(self):
+        with self._patch_entry_points([]):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(repos, [])
+        self.assertFalse(os.path.exists(
+            os.path.join(self.repos_path, "package_repos_cache.json")))
+
+    def test_entry_points_enumeration_failure_does_not_crash(self):
+        with patch.object(_mlc_action.importlib_metadata, "entry_points",
+                           side_effect=RuntimeError("boom")):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(repos, [])
+
+    # ---- 1.1/1.2 basic discovery ------------------------------------------
+
+    def test_basic_discovery_adds_repo_and_makes_script_searchable(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        pip_repos = [r for r in action.repos if r.meta.get("source") == "pip"]
+        self.assertEqual(len(pip_repos), 1)
+        self.assertEqual(pip_repos[0].meta["alias"], "mlc-scripts")
+        self.assertEqual(ep.load_call_count, 1)
+
+        res = action.search(
+            {"target_name": "script", "tags": "detect-widget"})
+        self.assertEqual(res["return"], 0)
+        self.assertEqual(len(res["list"]), 1)
+        self.assertTrue(res["list"][0].path.startswith(self.content_dir))
+
+    # ---- 3.1 caching: second run skips .load() -----------------------------
+
+    def test_cache_skips_reload_on_second_run_with_no_changes(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep1 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep1]):
+            discover_pip_script_repos(self.repos_path)
+        self.assertEqual(ep1.load_call_count, 1)
+
+        ep2 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep2]):
+            repos = discover_pip_script_repos(self.repos_path)
+
+        self.assertEqual(ep2.load_call_count, 0)
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repos[0].meta["alias"], "mlc-scripts")
+
+    def test_cache_file_written_only_when_something_changes(self):
+        cache_file = os.path.join(self.repos_path, "package_repos_cache.json")
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep1 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep1]):
+            discover_pip_script_repos(self.repos_path)
+        self.assertTrue(os.path.exists(cache_file))
+        mtime_after_first = os.path.getmtime(cache_file)
+
+        ep2 = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep2]):
+            discover_pip_script_repos(self.repos_path)
+        self.assertEqual(os.path.getmtime(cache_file), mtime_after_first)
+
+    def test_corrupted_cache_file_falls_back_gracefully(self):
+        os.makedirs(self.repos_path, exist_ok=True)
+        cache_file = os.path.join(self.repos_path, "package_repos_cache.json")
+        with open(cache_file, "w") as f:
+            f.write("{not valid json")
+
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            repos = discover_pip_script_repos(self.repos_path)
+
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(ep.load_call_count, 1)
+
+    # ---- 4.1 uninstall -> disappears ---------------------------------------
+
+    def test_uninstalled_package_disappears_on_next_discovery(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(len(repos), 1)
+
+        with self._patch_entry_points([]):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(repos, [])
+
+    def test_uninstalled_package_scripts_removed_from_index(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+        res = action.search({"target_name": "script", "tags": "detect-widget"})
+        self.assertEqual(len(res["list"]), 1)
+
+        with self._patch_entry_points([]):
+            action2 = self._new_action()
+        res2 = action2.search({"target_name": "script", "tags": "detect-widget"})
+        self.assertEqual(len(res2["list"]), 0)
+
+    # ---- 5.1 fork disambiguation (core design point) -----------------------
+
+    def test_fork_with_same_entry_point_name_different_distribution_coexist(self):
+        official_dir = os.path.join(self.temp_dir.name, "official_pkg")
+        fork_dir = os.path.join(self.temp_dir.name, "fork_pkg")
+        _write_script(official_dir, "detect-widget", "a" * 16)
+        _write_script(fork_dir, "new-fork-script", "b" * 16)
+
+        # Same self-chosen entry-point name on purpose - the whole point is
+        # that this must NOT matter.
+        ep_official = _FakeEntryPoint(
+            "mlperf-automations", "mlc-scripts", official_dir)
+        ep_fork = _FakeEntryPoint(
+            "mlperf-automations", "anandhu-mlc-scripts-fork", fork_dir)
+
+        from mlc.repo_action import RepoAction
+        with patch.object(RepoAction, "conflicting_repo") as mock_conflict:
+            with self._patch_entry_points([ep_official, ep_fork]):
+                action = self._new_action()
+        mock_conflict.assert_not_called()
+
+        pip_aliases = sorted(
+            r.meta["alias"] for r in action.repos if r.meta.get("source") == "pip")
+        self.assertEqual(pip_aliases, ["anandhu-mlc-scripts-fork", "mlc-scripts"])
+
+        res_official = action.search(
+            {"target_name": "script", "tags": "detect-widget"})
+        res_fork = action.search(
+            {"target_name": "script", "tags": "new-fork-script"})
+        self.assertEqual(len(res_official["list"]), 1)
+        self.assertEqual(len(res_fork["list"]), 1)
+
+    # ---- 8. cross-repo dependency resolution (both directions) ------------
+
+    def test_script_in_pip_repo_resolvable_as_dep_of_git_repo_script(self):
+        _write_script(self.content_dir, "get-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        git_repo_dir = os.path.join(self.temp_dir.name, "git_repo")
+        os.makedirs(git_repo_dir, exist_ok=True)
+        with open(os.path.join(git_repo_dir, "meta.yaml"), "w") as f:
+            import yaml
+            yaml.safe_dump({"alias": "git-repo", "uid": "c" * 16}, f)
+        _write_script(
+            git_repo_dir, "app-uses-widget", "d" * 16,
+            deps=[{"tags": "get-widget"}])
+
+        with open(os.path.join(self.repos_path, "repos.json"), "r+") as f:
+            import json
+            paths = json.load(f)
+            paths.append(git_repo_dir)
+            f.seek(0)
+            json.dump(paths, f)
+            f.truncate()
+
+        with self._patch_entry_points([ep]):
+            action2 = self._new_action()
+
+        dep_lookup = action2.search(
+            {"target_name": "script", "tags": "get-widget"})
+        self.assertEqual(len(dep_lookup["list"]), 1)
+        self.assertTrue(dep_lookup["list"][0].path.startswith(self.content_dir))
+
+    # ---- 9.1 broken package doesn't take down discovery for others --------
+
+    def test_broken_entry_point_is_skipped_others_still_discovered(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        good_ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        broken_ep = _FakeEntryPoint(
+            "broken-pkg", "broken-dist", "/nonexistent",
+            load_error=ImportError("simulated broken package"))
+
+        with self._patch_entry_points([broken_ep, good_ep]):
+            repos = discover_pip_script_repos(self.repos_path)
+
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repos[0].meta["alias"], "mlc-scripts")
+
+    def test_entry_point_resolving_to_missing_directory_is_skipped(self):
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", "/nonexistent/path")
+        with self._patch_entry_points([ep]):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(repos, [])
+
+    # ---- 10.1/10.2 mutation safety ------------------------------------------
+
+    def test_add_script_refused_for_pip_sourced_repo(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        res = action.add({
+            "item_repo": "mlc-scripts",
+            "item": "new-script-1",
+            "target_name": "script",
+        })
+        self.assertEqual(res["return"], 1)
+        self.assertIn("pip package", res["error"])
+        self.assertFalse(
+            os.path.exists(os.path.join(self.content_dir, "script", "new-script-1")))
+
+    def test_rm_repo_refused_for_pip_sourced_repo(self):
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        res = action.access(
+            {"action": "rm", "target": "repo", "repo": "mlc-scripts", "f": True})
+        self.assertEqual(res["return"], 1)
+        self.assertIn("pip uninstall", res["error"])
+        self.assertTrue(os.path.isdir(self.content_dir))
+
+    def test_cp_script_into_pip_sourced_repo_referenced_by_alias_is_refused(self):
+        # Regression test: the pip repo's on-disk directory basename
+        # ("content_pkg", a tempdir name) never matches its alias
+        # ("mlc-scripts", the distribution name) - cp()'s target-repo lookup
+        # used to match by basename only and would crash with a NameError
+        # instead of returning a clean refusal for exactly this mismatch.
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        res = action.cp({
+            "target": "script",
+            "src": "detect-widget",
+            "dest": "mlc-scripts:should-not-be-created",
+        })
+        self.assertEqual(res["return"], 1)
+        self.assertIn("pip package", res["error"])
+        self.assertFalse(os.path.exists(
+            os.path.join(self.content_dir, "script", "should-not-be-created")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pip_script_discovery.py
+++ b/tests/test_pip_script_discovery.py
@@ -108,6 +108,44 @@ class PipScriptDiscoveryTest(unittest.TestCase):
             repos = discover_pip_script_repos(self.repos_path)
         self.assertEqual(repos, [])
 
+    def test_pre_310_entry_points_api_fallback(self):
+        # Python <3.10: entry_points(group=...) raises TypeError (no such
+        # kwarg); callers must fall back to entry_points() with no args,
+        # which returns a plain dict (or dict-like SelectableGroups) keyed
+        # by group name.
+        _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        other_group_ep = _FakeEntryPoint("unrelated", "unrelated-dist", "/nonexistent")
+
+        def fake_entry_points(*args, **kwargs):
+            if "group" in kwargs:
+                raise TypeError(
+                    "entry_points() got an unexpected keyword argument 'group'")
+            return {
+                SCRIPT_PACKAGE_ENTRY_POINT_GROUP: [ep],
+                "some.other.group": [other_group_ep],
+            }
+
+        with patch.object(_mlc_action.importlib_metadata, "entry_points",
+                           side_effect=fake_entry_points):
+            repos = discover_pip_script_repos(self.repos_path)
+
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repos[0].meta["alias"], "mlc-scripts")
+        self.assertEqual(ep.load_call_count, 1)
+        self.assertEqual(other_group_ep.load_call_count, 0)
+
+    def test_pre_310_api_with_group_entirely_absent_is_noop(self):
+        def fake_entry_points(*args, **kwargs):
+            if "group" in kwargs:
+                raise TypeError("no group kwarg")
+            return {"some.other.group": []}
+
+        with patch.object(_mlc_action.importlib_metadata, "entry_points",
+                           side_effect=fake_entry_points):
+            repos = discover_pip_script_repos(self.repos_path)
+        self.assertEqual(repos, [])
+
     # ---- 1.1/1.2 basic discovery ------------------------------------------
 
     def test_basic_discovery_adds_repo_and_makes_script_searchable(self):
@@ -303,6 +341,24 @@ class PipScriptDiscoveryTest(unittest.TestCase):
         self.assertIn("pip package", res["error"])
         self.assertFalse(
             os.path.exists(os.path.join(self.content_dir, "script", "new-script-1")))
+
+    def test_rm_script_refused_for_pip_sourced_repo_and_reports_nothing_removed(self):
+        script_dir = _write_script(self.content_dir, "detect-widget", "a" * 16)
+        ep = _FakeEntryPoint("mlperf-automations", "mlc-scripts", self.content_dir)
+        with self._patch_entry_points([ep]):
+            action = self._new_action()
+
+        res = action.rm({
+            "target_name": "script",
+            "tags": "detect-widget",
+            "f": True,
+        })
+        # Must not falsely report success as if something were deleted.
+        self.assertEqual(res["return"], 0)
+        self.assertEqual(res.get("message"), "No items were removed")
+        self.assertNotIn("removed", res)
+        self.assertTrue(os.path.isdir(script_dir))
+        self.assertTrue(os.path.isfile(os.path.join(script_dir, "meta.yaml")))
 
     def test_rm_repo_refused_for_pip_sourced_repo(self):
         _write_script(self.content_dir, "detect-widget", "a" * 16)


### PR DESCRIPTION
## Summary
Implements the design from `mlcflow-pip-script-packages-proposal.pptx` (see issue #273 for the full proposal): mlcflow can discover script content from installed pip packages, as a second source alongside git-cloned repos in `~/MLC/repos`, via a new `mlc.script_packages` entry-point group.

- `discover_pip_script_repos()` enumerates installed distributions declaring the entry-point group, aliasing each repo by **distribution name** (not the self-chosen entry-point name), so a fork republished under a different distribution name coexists with the original even if both declare the same entry-point name and copy script uids verbatim.
- Results are cached in `package_repos_cache.json` so already-known distributions skip re-importing their resolver module; uninstalled distributions are simply left out, and `Index.build_index()`'s existing deleted-item detection prunes their content automatically.
- Pip-sourced repos are prepended (processed before git-cloned repos), so git repos still win any script-uid conflicts — pip is a lower-trust second source for this phase.
- Mutation-safety guards added to `Action.add/rm/cp` and `RepoAction.rm` (repo target) refusing to write into or delete a pip-sourced repo's directory, since that lives inside site-packages, not a user-owned git clone.
- Fixes a pre-existing bug surfaced by testing this: `cp()`'s target-repo lookup matched only by directory basename (crashing with a `NameError` on its own error path) instead of by alias.
- 18 new tests in `tests/test_pip_script_discovery.py`.

Base branch is `migrate-automation-engine-from-mlperf-automations` (this builds directly on the bundled-engine work in #271, not on `main`).

## Test plan
- [x] `python -m pytest tests/` — 25/25 passing (7 pre-existing + 18 new)
- [x] Verified end-to-end in a clean Docker container: pip-installed content package's script resolves a dependency on a git-cloned repo's script and runs correctly; a second, differently-named "fork" package coexists without conflict; uninstalling it makes it disappear from discovery
- [x] Verified backward compatibility: a classic git-clone-only setup (no pip packages installed, repo's own `automation/` folder still present) works with zero regression
- [x] Verified the mixed case: classic git-clone repo (with its `automation/` folder intact) *and* the pip package installed at the same time — no conflicts
- [x] Reviewed by an independent reviewer agent across two rounds; all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)