### PR TITLE
Engine: stamp script outputs with the owning repo's git version

### DIFF
--- a/mlc/engine/module.py
+++ b/mlc/engine/module.py
@@ -641,6 +641,28 @@ class ScriptAutomation(Automation):
         env['MLC_TMP_CURRENT_SCRIPT_REPO_PATH'] = script_repo_path
         env['MLC_TMP_CURRENT_SCRIPT_REPO_PATH_WITH_PREFIX'] = script_repo_path_with_prefix
 
+        # Stamp the env with the version (git commit) of the repo this script
+        # came from, so scripts can record provenance in their outputs. Uses the
+        # MLC_TMP_ prefix (in self.local_env_keys) so each script gets its OWN
+        # repo's version and dependency scripts never overwrite the parent's.
+        try:
+            from mlc.repo_version import get_repo_version
+            _repo_ver = get_repo_version(
+                script_repo_path, self.action_object.repos_path)
+            env['MLC_TMP_SCRIPTS_GIT_REPO'] = script_item.repo.meta.get(
+                'alias', '')
+            env['MLC_TMP_SCRIPTS_GIT_COMMIT'] = _repo_ver.get('commit', '')
+            env['MLC_TMP_SCRIPTS_GIT_BRANCH'] = _repo_ver.get('branch', '')
+            env['MLC_TMP_SCRIPTS_GIT_DIRTY'] = 'true' if _repo_ver.get(
+                'dirty') else 'false'
+            env['MLC_TMP_SCRIPTS_GIT_VERSION_SOURCE'] = _repo_ver.get(
+                'source', '')
+            if _repo_ver.get('version'):
+                env['MLC_TMP_SCRIPTS_PACKAGE_VERSION'] = _repo_ver['version']
+        except Exception as e:
+            self.logger.debug(
+                f"Could not resolve repo version for {script_repo_path}: {e}")
+
         run_state['script_id'] = meta['alias'] + "," + meta['uid']
         run_state['script_tags'] = script_tags
         run_state['script_variation_tags'] = variation_tags

--- a/mlc/repo_version.py
+++ b/mlc/repo_version.py
@@ -1,0 +1,163 @@
+"""Resolve a registered repo's code version (git commit / branch / dirty state).
+
+Script outputs (e.g. the MLPerf system-info JSONs) need to record the exact code
+that produced them. mlc-scripts has no tagged release — users track it with a
+plain ``git pull`` — so the Git commit of the automations checkout is the version.
+
+A repo's version changes only when the repo changes (pull / checkout / commit /
+local edit), never between two back-to-back ``mlc`` commands. Running ``git`` on
+every invocation would add a subprocess spawn per repo for a value that rarely
+moves. So we cache the result in a sidecar (``repos_version.json``) keyed by repo
+path and recompute only when ``.git/HEAD`` or ``.git/index`` mtime changes — the
+same mtime-gating trick ``index.py`` uses for ``modified_times.json``.
+
+Caveat: ``commit`` and ``branch`` are always accurate (HEAD/index move on every
+pull / checkout / commit). The ``dirty`` flag is best-effort — editing a tracked
+file without staging it does not touch ``.git/index``, so a freshly-dirtied tree
+can report ``dirty: false`` until the next git operation. ``commit`` remains the
+authoritative version identifier.
+
+Resolution order (so the result is never empty):
+  1. git         — rev-parse HEAD + branch + dirty flag
+  2. commit_file — git_commit_hash.txt written at build time (pip installs)
+  3. package     — installed mlc-scripts package version
+  4. unknown     — nothing could be resolved
+"""
+
+import os
+import json
+import subprocess
+
+try:
+    import filelock
+except Exception:  # pragma: no cover - filelock is a declared dependency
+    filelock = None
+
+SIDECAR_NAME = "repos_version.json"
+
+# Keys stored only for cache invalidation; stripped from the returned version.
+_CACHE_ONLY_KEYS = ("head_mtime", "index_mtime")
+
+
+def _git(repo_path, *args):
+    return subprocess.check_output(
+        ["git", "-C", repo_path, *args],
+        stderr=subprocess.DEVNULL, text=True).strip()
+
+
+def _mtime(path):
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _compute_from_git(repo_path):
+    commit = _git(repo_path, "rev-parse", "HEAD")
+    branch = _git(repo_path, "rev-parse", "--abbrev-ref", "HEAD")
+    # -uno: ignore untracked files; we only care about tracked-file changes.
+    dirty = bool(_git(repo_path, "status", "--porcelain", "-uno"))
+    return {"source": "git", "commit": commit,
+            "branch": branch, "dirty": dirty}
+
+
+def _fallback(repo_path):
+    """Resolve a version without git: build hash file, then package version."""
+    hash_file = os.path.join(repo_path, "git_commit_hash.txt")
+    if os.path.isfile(hash_file):
+        try:
+            with open(hash_file) as f:
+                commit = f.read().strip()
+            if commit:
+                return {"source": "commit_file", "commit": commit,
+                        "branch": "", "dirty": False}
+        except OSError:
+            pass
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return {"source": "package", "commit": "", "branch": "",
+                    "dirty": False, "version": version("mlc-scripts")}
+        except PackageNotFoundError:
+            pass
+    except Exception:
+        pass
+    return {"source": "unknown", "commit": "", "branch": "", "dirty": False}
+
+
+def _strip_cache_keys(entry):
+    return {k: v for k, v in entry.items() if k not in _CACHE_ONLY_KEYS}
+
+
+def get_repo_version(repo_path, repos_path):
+    """Return a version dict for ``repo_path`` using an mtime-gated sidecar cache.
+
+    Args:
+      repo_path:  absolute path to the repo checkout.
+      repos_path: the MLC repos root (where the sidecar cache lives).
+
+    Returns a dict with at least ``source`` and (when available) ``commit``,
+    ``branch``, ``dirty`` and ``version``.
+    """
+    git_dir = os.path.join(repo_path, ".git")
+    head_mtime = _mtime(os.path.join(git_dir, "HEAD"))
+
+    if head_mtime is None:
+        # No .git/HEAD to mtime-gate on. If .git still exists (e.g. a git
+        # worktree/submodule where .git is a FILE, not a directory), git
+        # commands still work via `git -C` but we have no cheap change signal,
+        # so compute fresh and uncached. If .git is absent entirely (e.g. a pip
+        # install), fall back to the hash file / package version.
+        if os.path.exists(git_dir):
+            try:
+                return _compute_from_git(repo_path)
+            except Exception:
+                return _fallback(repo_path)
+        return _fallback(repo_path)
+
+    index_mtime = _mtime(os.path.join(git_dir, "index"))
+
+    def _resolve():
+        try:
+            return _compute_from_git(repo_path)
+        except Exception:
+            return _fallback(repo_path)
+
+    sidecar = os.path.join(repos_path, SIDECAR_NAME)
+
+    # Without filelock we still work correctly, just uncached.
+    if filelock is None:
+        return _resolve()
+
+    lock = filelock.FileLock(sidecar + ".lock")
+    try:
+        with lock.acquire(timeout=10):
+            cache = {}
+            if os.path.isfile(sidecar):
+                try:
+                    with open(sidecar) as f:
+                        cache = json.load(f)
+                    if not isinstance(cache, dict):
+                        cache = {}
+                except (json.JSONDecodeError, OSError):
+                    cache = {}
+
+            entry = cache.get(repo_path)
+            if (isinstance(entry, dict)
+                    and entry.get("head_mtime") == head_mtime
+                    and entry.get("index_mtime") == index_mtime):
+                # Cheap path: nothing changed since we last computed.
+                return _strip_cache_keys(entry)
+
+            info = _resolve()
+            cache[repo_path] = {**info, "head_mtime": head_mtime,
+                                "index_mtime": index_mtime}
+            try:
+                with open(sidecar, "w") as f:
+                    json.dump(cache, f, indent=2)
+            except OSError:
+                pass
+            return info
+    except Exception:
+        # Lock timeout or any I/O problem: compute without caching.
+        return _resolve()


### PR DESCRIPTION
## Problem
`mlc-scripts` has no tagged release — users track it via `git pull`, so a script's output cannot be traced back to the exact code that produced it.

## Why this targets `migration-option-b` (not `main`)
This change lives in `mlc/engine/module.py`, which only exists on the Option-B architecture (the engine moved into mlcflow). `main` has no `mlc/engine/`, so the change is not applicable there. The companion **script** changes for the currently-live architecture are a separate PR against `mlcommons/mlperf-automations:main` (mlperf-automations#1055).

## Approach
- **`mlc/repo_version.py`** (new) — resolves a repo's `{source, commit, branch, dirty, [version]}` with an **mtime-gated sidecar cache** (`repos_version.json`, keyed by repo path; recomputed only when `.git/HEAD` / `.git/index` change). Fallback chain: `git` → `git_commit_hash.txt` → installed `mlc-scripts` package version → `unknown`. Never raises into the engine (all paths guarded; degrades to uncached compute on lock timeout).
- **`mlc/engine/module.py`** — right after the existing `MLC_TMP_CURRENT_SCRIPT_REPO_PATH` assignment, injects `MLC_TMP_SCRIPTS_GIT_REPO/COMMIT/BRANCH/DIRTY/VERSION_SOURCE` (+ `MLC_TMP_SCRIPTS_PACKAGE_VERSION` when applicable) for the repo that owns the running script. The `MLC_TMP_` prefix is in `self.local_env_keys`, so these vars are stripped before dependency scripts run and restored for the parent — each script sees **its own** repo's version, never a dependency's.

## Consumer
Scripts read these vars and record provenance in their outputs (e.g. an `mlc_scripts_version` block in the system-info JSONs). See mlperf-automations#1055.

## Notes / limitations
- Lazy + cached: git runs only on the first call per repo per changed state, not on every `mlc` startup — no per-command overhead.
- The `dirty` flag is best-effort under the mtime cache (a tracked-file edit that doesn't touch `.git/index` may report `dirty:false` until the next git op); `commit` is authoritative. Documented in the module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)