### PR TITLE
Add repo_version resolver (git version stamping for script outputs)

### DIFF
--- a/mlc/repo_version.py
+++ b/mlc/repo_version.py
@@ -25,6 +25,7 @@ Resolution order (so the result is never empty):
 """
 
 import os
+import re
 import json
 import logging
 import subprocess
@@ -44,6 +45,13 @@ _LOCK_TIMEOUT = 10
 
 # Keys stored only for cache invalidation; stripped from the returned version.
 _CACHE_ONLY_KEYS = ("head_mtime", "index_mtime")
+
+# A git commit is an abbreviated-to-full hex SHA (sha1 is 40, sha256 is 64).
+_COMMIT_RE = re.compile(r"\A[0-9a-fA-F]{7,64}\Z")
+
+
+def _looks_like_commit(value):
+    return bool(value) and bool(_COMMIT_RE.match(value))
 
 
 def _git(repo_path, *args):
@@ -75,10 +83,15 @@ def _fallback(repo_path):
         try:
             with open(hash_file) as f:
                 commit = f.read().strip()
-            if commit:
+            if _looks_like_commit(commit):
                 return {"source": "commit_file", "commit": commit,
                         "branch": "", "dirty": False}
-            logger.debug("git_commit_hash.txt in %s is empty", repo_path)
+            if commit:
+                logger.debug(
+                    "git_commit_hash.txt in %s is not a valid commit hash: %r",
+                    repo_path, commit)
+            else:
+                logger.debug("git_commit_hash.txt in %s is empty", repo_path)
         except OSError as e:
             logger.debug("Could not read %s: %s", hash_file, e)
     else:
@@ -110,6 +123,14 @@ def get_repo_version(repo_path, repos_path):
 
     Returns a dict with at least ``source`` and (when available) ``commit``,
     ``branch``, ``dirty`` and ``version``.
+
+    Notes:
+      ``commit`` / ``branch`` are authoritative. ``dirty`` is best-effort: it
+      uses ``git status --porcelain -uno`` (untracked files are intentionally
+      ignored), and because the result is cached behind ``.git/HEAD`` /
+      ``.git/index`` mtimes, an unstaged edit to a tracked file may not refresh
+      it until the next git operation. Treat ``dirty`` as a hint, not a
+      guarantee.
     """
     git_dir = os.path.join(repo_path, ".git")
     head_mtime = _mtime(os.path.join(git_dir, "HEAD"))
@@ -123,7 +144,10 @@ def get_repo_version(repo_path, repos_path):
         if os.path.exists(git_dir):
             try:
                 return _compute_from_git(repo_path)
-            except Exception:
+            except Exception as e:
+                logger.debug(
+                    "git version failed for %s: %s; falling back",
+                    repo_path, e)
                 return _fallback(repo_path)
         return _fallback(repo_path)
 
@@ -132,13 +156,17 @@ def get_repo_version(repo_path, repos_path):
     def _resolve():
         try:
             return _compute_from_git(repo_path)
-        except Exception:
+        except Exception as e:
+            logger.debug(
+                "git version failed for %s: %s; falling back", repo_path, e)
             return _fallback(repo_path)
 
     sidecar = os.path.join(repos_path, SIDECAR_NAME)
 
     # Without filelock we still work correctly, just uncached.
     if filelock is None:
+        logger.debug(
+            "filelock unavailable; computing repo version uncached")
         return _resolve()
 
     lock = filelock.FileLock(sidecar + ".lock")

--- a/mlc/repo_version.py
+++ b/mlc/repo_version.py
@@ -43,6 +43,10 @@ SIDECAR_NAME = "repos_version.json"
 # compute. Kept as a module constant so it is easy to tune in one place.
 _LOCK_TIMEOUT = 10
 
+# Seconds to allow a single git subprocess before giving up (guards against a
+# hung git so version resolution can never block a script run indefinitely).
+_GIT_TIMEOUT = 30
+
 # Keys stored only for cache invalidation; stripped from the returned version.
 _CACHE_ONLY_KEYS = ("head_mtime", "index_mtime")
 
@@ -57,7 +61,7 @@ def _looks_like_commit(value):
 def _git(repo_path, *args):
     return subprocess.check_output(
         ["git", "-C", repo_path, *args],
-        stderr=subprocess.DEVNULL, text=True).strip()
+        stderr=subprocess.DEVNULL, text=True, timeout=_GIT_TIMEOUT).strip()
 
 
 def _mtime(path):
@@ -132,6 +136,9 @@ def get_repo_version(repo_path, repos_path):
       it until the next git operation. Treat ``dirty`` as a hint, not a
       guarantee.
     """
+    # Normalise so the sidecar cache key is stable regardless of how the caller
+    # spelled the path (relative vs absolute, symlinks, trailing slash).
+    repo_path = os.path.realpath(repo_path)
     git_dir = os.path.join(repo_path, ".git")
     head_mtime = _mtime(os.path.join(git_dir, "HEAD"))
 
@@ -203,5 +210,6 @@ def get_repo_version(repo_path, repos_path):
     except Exception as e:
         # Lock timeout or any I/O problem: compute without caching.
         logger.debug(
-            "repos_version cache unavailable (%s); computing uncached", e)
+            "repos_version cache unavailable (%s); computing uncached", e,
+            exc_info=True)
         return _resolve()

--- a/mlc/repo_version.py
+++ b/mlc/repo_version.py
@@ -26,6 +26,7 @@ Resolution order (so the result is never empty):
 
 import os
 import json
+import logging
 import subprocess
 
 try:
@@ -33,7 +34,13 @@ try:
 except Exception:  # pragma: no cover - filelock is a declared dependency
     filelock = None
 
+logger = logging.getLogger(__name__)
+
 SIDECAR_NAME = "repos_version.json"
+
+# Seconds to wait for the sidecar lock before falling back to an uncached
+# compute. Kept as a module constant so it is easy to tune in one place.
+_LOCK_TIMEOUT = 10
 
 # Keys stored only for cache invalidation; stripped from the returned version.
 _CACHE_ONLY_KEYS = ("head_mtime", "index_mtime")
@@ -71,17 +78,22 @@ def _fallback(repo_path):
             if commit:
                 return {"source": "commit_file", "commit": commit,
                         "branch": "", "dirty": False}
-        except OSError:
-            pass
+            logger.debug("git_commit_hash.txt in %s is empty", repo_path)
+        except OSError as e:
+            logger.debug("Could not read %s: %s", hash_file, e)
+    else:
+        logger.debug("No git_commit_hash.txt in %s", repo_path)
     try:
         from importlib.metadata import version, PackageNotFoundError
         try:
             return {"source": "package", "commit": "", "branch": "",
                     "dirty": False, "version": version("mlc-scripts")}
         except PackageNotFoundError:
-            pass
-    except Exception:
-        pass
+            logger.debug("mlc-scripts package metadata not found")
+    except Exception as e:
+        logger.debug("mlc-scripts version lookup failed: %s", e)
+    logger.debug(
+        "Could not resolve a version for %s (source=unknown)", repo_path)
     return {"source": "unknown", "commit": "", "branch": "", "dirty": False}
 
 
@@ -131,7 +143,7 @@ def get_repo_version(repo_path, repos_path):
 
     lock = filelock.FileLock(sidecar + ".lock")
     try:
-        with lock.acquire(timeout=10):
+        with lock.acquire(timeout=_LOCK_TIMEOUT):
             cache = {}
             if os.path.isfile(sidecar):
                 try:
@@ -139,7 +151,9 @@ def get_repo_version(repo_path, repos_path):
                         cache = json.load(f)
                     if not isinstance(cache, dict):
                         cache = {}
-                except (json.JSONDecodeError, OSError):
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.debug(
+                        "Ignoring unreadable %s (%s); rebuilding", sidecar, e)
                     cache = {}
 
             entry = cache.get(repo_path)
@@ -158,6 +172,8 @@ def get_repo_version(repo_path, repos_path):
             except OSError:
                 pass
             return info
-    except Exception:
+    except Exception as e:
         # Lock timeout or any I/O problem: compute without caching.
+        logger.debug(
+            "repos_version cache unavailable (%s); computing uncached", e)
         return _resolve()

--- a/mlc/repo_version.py
+++ b/mlc/repo_version.py
@@ -1,0 +1,163 @@
+"""Resolve a registered repo's code version (git commit / branch / dirty state).
+
+Script outputs (e.g. the MLPerf system-info JSONs) need to record the exact code
+that produced them. mlc-scripts has no tagged release — users track it with a
+plain ``git pull`` — so the Git commit of the automations checkout is the version.
+
+A repo's version changes only when the repo changes (pull / checkout / commit /
+local edit), never between two back-to-back ``mlc`` commands. Running ``git`` on
+every invocation would add a subprocess spawn per repo for a value that rarely
+moves. So we cache the result in a sidecar (``repos_version.json``) keyed by repo
+path and recompute only when ``.git/HEAD`` or ``.git/index`` mtime changes — the
+same mtime-gating trick ``index.py`` uses for ``modified_times.json``.
+
+Caveat: ``commit`` and ``branch`` are always accurate (HEAD/index move on every
+pull / checkout / commit). The ``dirty`` flag is best-effort — editing a tracked
+file without staging it does not touch ``.git/index``, so a freshly-dirtied tree
+can report ``dirty: false`` until the next git operation. ``commit`` remains the
+authoritative version identifier.
+
+Resolution order (so the result is never empty):
+  1. git         — rev-parse HEAD + branch + dirty flag
+  2. commit_file — git_commit_hash.txt written at build time (pip installs)
+  3. package     — installed mlc-scripts package version
+  4. unknown     — nothing could be resolved
+"""
+
+import os
+import json
+import subprocess
+
+try:
+    import filelock
+except Exception:  # pragma: no cover - filelock is a declared dependency
+    filelock = None
+
+SIDECAR_NAME = "repos_version.json"
+
+# Keys stored only for cache invalidation; stripped from the returned version.
+_CACHE_ONLY_KEYS = ("head_mtime", "index_mtime")
+
+
+def _git(repo_path, *args):
+    return subprocess.check_output(
+        ["git", "-C", repo_path, *args],
+        stderr=subprocess.DEVNULL, text=True).strip()
+
+
+def _mtime(path):
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _compute_from_git(repo_path):
+    commit = _git(repo_path, "rev-parse", "HEAD")
+    branch = _git(repo_path, "rev-parse", "--abbrev-ref", "HEAD")
+    # -uno: ignore untracked files; we only care about tracked-file changes.
+    dirty = bool(_git(repo_path, "status", "--porcelain", "-uno"))
+    return {"source": "git", "commit": commit,
+            "branch": branch, "dirty": dirty}
+
+
+def _fallback(repo_path):
+    """Resolve a version without git: build hash file, then package version."""
+    hash_file = os.path.join(repo_path, "git_commit_hash.txt")
+    if os.path.isfile(hash_file):
+        try:
+            with open(hash_file) as f:
+                commit = f.read().strip()
+            if commit:
+                return {"source": "commit_file", "commit": commit,
+                        "branch": "", "dirty": False}
+        except OSError:
+            pass
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return {"source": "package", "commit": "", "branch": "",
+                    "dirty": False, "version": version("mlc-scripts")}
+        except PackageNotFoundError:
+            pass
+    except Exception:
+        pass
+    return {"source": "unknown", "commit": "", "branch": "", "dirty": False}
+
+
+def _strip_cache_keys(entry):
+    return {k: v for k, v in entry.items() if k not in _CACHE_ONLY_KEYS}
+
+
+def get_repo_version(repo_path, repos_path):
+    """Return a version dict for ``repo_path`` using an mtime-gated sidecar cache.
+
+    Args:
+      repo_path:  absolute path to the repo checkout.
+      repos_path: the MLC repos root (where the sidecar cache lives).
+
+    Returns a dict with at least ``source`` and (when available) ``commit``,
+    ``branch``, ``dirty`` and ``version``.
+    """
+    git_dir = os.path.join(repo_path, ".git")
+    head_mtime = _mtime(os.path.join(git_dir, "HEAD"))
+
+    if head_mtime is None:
+        # No .git/HEAD to mtime-gate on. If .git still exists (e.g. a git
+        # worktree/submodule where .git is a FILE, not a directory), git
+        # commands still work via `git -C` but we have no cheap change signal,
+        # so compute fresh and uncached. If .git is absent entirely (e.g. a pip
+        # install), fall back to the hash file / package version.
+        if os.path.exists(git_dir):
+            try:
+                return _compute_from_git(repo_path)
+            except Exception:
+                return _fallback(repo_path)
+        return _fallback(repo_path)
+
+    index_mtime = _mtime(os.path.join(git_dir, "index"))
+
+    def _resolve():
+        try:
+            return _compute_from_git(repo_path)
+        except Exception:
+            return _fallback(repo_path)
+
+    sidecar = os.path.join(repos_path, SIDECAR_NAME)
+
+    # Without filelock we still work correctly, just uncached.
+    if filelock is None:
+        return _resolve()
+
+    lock = filelock.FileLock(sidecar + ".lock")
+    try:
+        with lock.acquire(timeout=10):
+            cache = {}
+            if os.path.isfile(sidecar):
+                try:
+                    with open(sidecar) as f:
+                        cache = json.load(f)
+                    if not isinstance(cache, dict):
+                        cache = {}
+                except (json.JSONDecodeError, OSError):
+                    cache = {}
+
+            entry = cache.get(repo_path)
+            if (isinstance(entry, dict)
+                    and entry.get("head_mtime") == head_mtime
+                    and entry.get("index_mtime") == index_mtime):
+                # Cheap path: nothing changed since we last computed.
+                return _strip_cache_keys(entry)
+
+            info = _resolve()
+            cache[repo_path] = {**info, "head_mtime": head_mtime,
+                                "index_mtime": index_mtime}
+            try:
+                with open(sidecar, "w") as f:
+                    json.dump(cache, f, indent=2)
+            except OSError:
+                pass
+            return info
+    except Exception:
+        # Lock timeout or any I/O problem: compute without caching.
+        return _resolve()


### PR DESCRIPTION
## Problem
`mlc-scripts` has no tagged release — users track it via `git pull`, so a script's output cannot be traced back to the exact code that produced it.

## What this adds
**`mlc/repo_version.py`** — resolves a repo's `{source, commit, branch, dirty, [version]}`:
- **mtime-gated sidecar cache** (`repos_version.json`, keyed by repo path; recomputed only when `.git/HEAD` / `.git/index` change) — so git runs only when the repo actually changed, not on every command.
- Fallback chain: `git` → `git_commit_hash.txt` → installed `mlc-scripts` package version → `unknown`.
- `.git`-as-a-file (git worktrees/submodules) handled.
- Every path guarded — never raises into a caller; degrades to an uncached compute on lock timeout.

## How it's consumed
The script execution engine resolves the owning repo's version once per run and injects `MLC_TMP_SCRIPTS_GIT_*` env vars; the system-info scripts write an `mlc_scripts_version` block into their output JSON. On the current (live) architecture the engine is loaded from `mlperf-automations`, so the engine injection + script consumers ship there: **mlcommons/mlperf-automations#1055**.

This PR places the resolver in the driver package (its natural, architecture-agnostic home) so any engine — the current external one or the in-tree Option-B engine — can import it via `from mlc.repo_version import get_repo_version`.

## Example output stamped by the consumer
```json
"mlc_scripts_version": {
  "repo": "mlcommons@mlperf-automations",
  "commit": "20d3d94c4fbbefca1a69f0e2b23295d196fd3e63",
  "branch": "main",
  "dirty": false,
  "source": "git"
}
```

## Notes
- The `dirty` flag is best-effort under the mtime cache; `commit` is authoritative. Documented in the module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)