### PR TITLE
Add utils.get_repo_version for stamping script outputs

### DIFF
--- a/mlc/main.py
+++ b/mlc/main.py
@@ -97,32 +97,14 @@ def get_version_info():
 
 def _get_repo_hashes():
     """Get git info for all repos. Returns list of (alias, branch, hash, has_local_changes)."""
-    import subprocess
     if default_parent is None:
         return []
     results = []
     for repo in default_parent.repos:
-        alias = os.path.basename(repo.path)
-        git_dir = os.path.join(repo.path, '.git')
-        if not os.path.isdir(git_dir):
-            continue
-        try:
-            commit = subprocess.check_output(
-                ["git", "-C", repo.path, "rev-parse", "--short", "HEAD"],
-                stderr=subprocess.DEVNULL, text=True
-            ).strip()
-            branch = subprocess.check_output(
-                ["git", "-C", repo.path, "rev-parse", "--abbrev-ref", "HEAD"],
-                stderr=subprocess.DEVNULL, text=True
-            ).strip()
-            # Only tracked file changes (ignore untracked files)
-            dirty = subprocess.check_output(
-                ["git", "-C", repo.path, "status", "--porcelain", "-uno"],
-                stderr=subprocess.DEVNULL, text=True
-            ).strip()
-            results.append((alias, branch, commit, bool(dirty)))
-        except Exception:
-            pass
+        v = utils.get_repo_version(repo.path)
+        if v.get("source") == "git":
+            results.append((os.path.basename(repo.path), v["branch"],
+                            v["commit"][:9], v["dirty"]))
     return results
 
 

--- a/mlc/utils.py
+++ b/mlc/utils.py
@@ -20,7 +20,8 @@ def get_repo_version(repo_path):
 
     Returns ``{source, commit, branch, dirty}`` (``source='git'``), or a
     ``git_commit_hash.txt`` fallback for pip installs (``source='commit_file'``),
-    or ``{}`` if nothing can be resolved. Computed fresh (no caching).
+    or an empty dict ``{}`` when neither is available (callers should treat an
+    empty result as "version unknown"). Computed fresh (no caching).
 
     Used by ``main._get_repo_hashes`` (the on-error hash display) and by scripts
     that stamp their output with the producing repo's version.
@@ -48,6 +49,9 @@ def get_repo_version(repo_path):
             with open(hash_file) as f:
                 commit = f.read().strip()
             if commit:
+                logger.debug(
+                    "get_repo_version: using git_commit_hash.txt for %s (no git)",
+                    repo_path)
                 return {"source": "commit_file", "commit": commit,
                         "branch": "", "dirty": False}
         except OSError:

--- a/mlc/utils.py
+++ b/mlc/utils.py
@@ -41,8 +41,11 @@ def get_repo_version(repo_path):
                 # Only tracked file changes (ignore untracked files)
                 "dirty": bool(_git("status", "--porcelain", "-uno")),
             }
-        except Exception:
-            pass
+        except Exception as e:
+            # Broad by design: never raise into a caller. Log for debugging.
+            logger.debug(
+                "get_repo_version: git failed for %s (%s); trying fallback",
+                repo_path, e)
     hash_file = os.path.join(repo_path, "git_commit_hash.txt")
     if os.path.isfile(hash_file):
         try:

--- a/mlc/utils.py
+++ b/mlc/utils.py
@@ -15,6 +15,46 @@ import logging
 logger = logging.getLogger("mlc")
 
 
+def get_repo_version(repo_path):
+    """Resolve the git version of a single repo checkout.
+
+    Returns ``{source, commit, branch, dirty}`` (``source='git'``), or a
+    ``git_commit_hash.txt`` fallback for pip installs (``source='commit_file'``),
+    or ``{}`` if nothing can be resolved. Computed fresh (no caching).
+
+    Used by ``main._get_repo_hashes`` (the on-error hash display) and by scripts
+    that stamp their output with the producing repo's version.
+    """
+    if not repo_path:
+        return {}
+    if os.path.isdir(os.path.join(repo_path, '.git')):
+        def _git(*args):
+            return subprocess.check_output(
+                ["git", "-C", repo_path, *args],
+                stderr=subprocess.DEVNULL, text=True).strip()
+        try:
+            return {
+                "source": "git",
+                "commit": _git("rev-parse", "HEAD"),
+                "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+                # Only tracked file changes (ignore untracked files)
+                "dirty": bool(_git("status", "--porcelain", "-uno")),
+            }
+        except Exception:
+            pass
+    hash_file = os.path.join(repo_path, "git_commit_hash.txt")
+    if os.path.isfile(hash_file):
+        try:
+            with open(hash_file) as f:
+                commit = f.read().strip()
+            if commit:
+                return {"source": "commit_file", "commit": commit,
+                        "branch": "", "dirty": False}
+        except OSError:
+            pass
+    return {}
+
+
 def generate_temp_file(i):
     """
     Generate a temporary file and optionally clean up the directory.


### PR DESCRIPTION
Adds `utils.get_repo_version(repo_path)` — returns a repo checkout's `{source, commit, branch, dirty}` (git, with a `git_commit_hash.txt` fallback).

`main._get_repo_hashes()` (the on-error hash display) now reuses it, and the MLPerf system-info scripts import it to stamp their output with the producing repo's version. One git implementation, no new module, no cache.

Companion: mlcommons/mlperf-automations (system-info scripts that call this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)