### PR TITLE
Fix stale index after auto-pulling mlcommons@mlperf-automations

### DIFF
--- a/.claude/skill.md
+++ b/.claude/skill.md
@@ -221,4 +221,7 @@ python -m pytest tests/
 - Don't push directly to `main` — open a PR; use `dev` only for urgent merges without approval
 - Don't hard-code `~/MLC/repos` — use `self.repos_path` (which reads `MLC_REPOS` env var)
 - Don't edit `index_script.json` or `modified_times.json` by hand — use `mlc reindex`
+- Don't write `self.__dict__.update(vars(parent))` in an Action subclass `__init__` — call `self._inherit_from_parent(parent)`; `repos`/`_index` resolve to one owner per process (`Action._state_owner()`), so never copy them back onto `self.parent` by hand
+- Don't turn `self.parent.rm(i)` / `self.parent.search(i)` in `CacheAction`/`ScriptAction` into `super()` — those need the *base* receiver, or `mlc rm cache` starts skipping expired caches
+- Don't read-modify-write `repos.json` without `repo_action.repos_json_lock()`, and don't call anything that takes that lock from inside it (same-file `FileLock`s deadlock in one process)
 - Don't call `ScriptAutomation` directly — always go through `call_script_module_function()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,21 @@ this reason.
 
 ---
 
+## Comment style
+
+- Comment *why code is this way* (a non-obvious invariant, a trade-off, a
+  constraint another part of the codebase imposes) — keep it concise, a
+  sentence or two.
+- Don't comment *why code used to be different* ("previously this did X",
+  "removed the Y workaround", "no longer need to..."). That history belongs in
+  the commit message or PR description, not in a comment that outlives the
+  PR and has nothing to contrast against for a reader who never saw the old
+  code.
+- Don't explain *what* the code does when the code already says it — comment
+  the reasoning, not a restatement of the next line.
+
+---
+
 ## Branch policy
 
 - PRs target `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,37 @@ For `script` target: variation tags (prefixed `_`) are stripped before
 matching. For `cache`/`experiment`: all tags are matched. Negative tags use
 `-` prefix.
 
+### State ownership — `repos` and the index live on one object per process
+
+`get_action()` builds a **fresh, throwaway delegate** (`RepoAction`,
+`ScriptAction`, …) for every dispatch, while the state those delegates mutate
+has to outlive them: `default_parent` is the long-lived root reused for every
+later `search()`/`find()`/`rm()` in the same process.
+
+`Action._state_owner()` walks the `parent` chain and returns that root.
+`Action.repos` is a property that reads/writes through it, and `get_index()`
+caches the `Index` on it. So:
+
+- `self.repos = self.load_repos_and_meta()` inside any delegate updates the
+  state every *other* delegate sees — no copying back onto `self.parent`.
+- `self.get_index()` returns the same `Index` object everywhere, built once.
+- Subclass `__init__` must call `self._inherit_from_parent(parent)`, never
+  `self.__dict__.update(vars(parent))`. The helper copies startup config
+  (`repos_path`, `local_cache_path`, …) but deliberately **not** `repos`,
+  `_index` or `parent` (`Action._NOT_INHERITED`) — copying state would create a
+  second copy that diverges on the next write, and copying `parent` would let a
+  grandparent replace the parent and collapse the chain.
+- A parent that is not an `Action` (test stubs holding just `repos_path`) can't
+  own state, so that delegate owns its own. `parent=None` makes the delegate a
+  root via `Action.__init__`.
+
+`CacheAction.rm()`/`search()` and `ScriptAction.rm()`/`search()` still call
+`self.parent.rm(i)` / `self.parent.search(i)`. That is **not** a state
+workaround and must not become `super()`: those methods override the base ones,
+and `Action.rm()` calls `self.search()`, so a `CacheAction` receiver would apply
+the expiry filter and skip exactly the expired caches `mlc rm cache` is meant to
+delete.
+
 ### `Index` class (`index.py`)
 
 Maintains three index files plus `modified_times.json`:
@@ -466,6 +497,19 @@ should not normally be triggered if the repo is already registered.
 i.get("template_tags", "template,generic")`. If multiple scripts match
 `template_tags`, it interactively prompts. Passing an exact unique tag set
 avoids the prompt.
+
+**8. Every `repos.json` write needs `repos_json_lock()`, and must not nest**
+Registering/unregistering is a read-modify-write of one shared list, so two
+concurrent `mlc pull repo` runs can otherwise lose an entry (or a reader hits a
+half-written file). `register_repo()` and `unregister_repo()` hold
+`repo_action.repos_json_lock()` across the whole read-modify-write and write via
+`utils.save_json_atomic()` so unlocked readers never see a partial file.
+
+Keep the locked region narrow: **nothing inside it may call a function that
+takes the same lock** — two `FileLock` objects on one file deadlock even within a
+single process. `register_repo()` unregisters conflicting repos and pulls deps
+*before* entering the lock, and reloads repos *after* leaving it, for exactly
+this reason.
 
 ---
 

--- a/mlc/action.py
+++ b/mlc/action.py
@@ -26,7 +26,69 @@ class Action:
     logger = None
     local_repo = None
     current_repo_path = None
-    repos = []  # list of Repo objects
+    parent = None
+
+    # Backing state for the `repos` property and get_index(). These live on a
+    # single object per process (see _state_owner()), so the values here are
+    # only the defaults for an object that owns its own state.
+    _repos = []  # list of Repo objects
+    _index = None
+
+    # Never handed down to a delegate: copying the state fields would create a
+    # second copy that diverges from the owner's the moment either changes,
+    # and copying `parent` would collapse the chain the delegate resolves
+    # through (a grandparent would silently replace its parent).
+    _NOT_INHERITED = ('parent', '_repos', '_index')
+
+    def _state_owner(self):
+        """Return the one object that owns repos/index state for this chain.
+
+        Action subclasses are throwaway delegates - get_action() builds a fresh
+        one per dispatch - while the state they mutate has to outlive them: the
+        long-lived root (`default_parent`) is reused for every later
+        search()/find()/rm() in the same process. Resolving through that root
+        means a repo pulled by one delegate is visible to the next one at once,
+        instead of each delegate mutating a private copy that has to be pushed
+        back by hand.
+
+        A parent that is not an Action (tests pass a stub carrying just
+        repos_path) cannot own state, so there the delegate owns its own.
+        """
+        owner = self
+        seen = {id(owner)}
+        while isinstance(owner.parent, Action):
+            if id(owner.parent) in seen:
+                break  # self-referential chain; stop instead of looping
+            owner = owner.parent
+            seen.add(id(owner))
+        return owner
+
+    def _inherit_from_parent(self, parent):
+        """Set this delegate up from the object that dispatched to it.
+
+        Configuration (repos_path, local_cache_path, ...) is copied because it
+        does not change after startup; repos/index deliberately are not - see
+        _state_owner() and _NOT_INHERITED.
+        """
+        self.parent = parent
+
+        if parent is None:
+            # No one to inherit from, so this instance owns its own state.
+            Action.__init__(self)
+            return
+
+        for key, value in vars(parent).items():
+            if key not in Action._NOT_INHERITED:
+                setattr(self, key, value)
+
+    @property
+    def repos(self):
+        """The registered repos, resolved from the state owner (never a copy)."""
+        return self._state_owner()._repos
+
+    @repos.setter
+    def repos(self, value):
+        self._state_owner()._repos = value
 
     # Main access function to simulate a Python interface for CLI
     def access(self, options):
@@ -217,9 +279,12 @@ class Action:
             return None
 
     def get_index(self):
-        if self._index is None:
-            self._index = Index(self.repos_path, self.repos)
-        return self._index
+        # Built once per process and cached on the state owner, so a delegate
+        # never rebuilds an index the root already has (or vice versa).
+        owner = self._state_owner()
+        if owner._index is None:
+            owner._index = Index(owner.repos_path, owner.repos)
+        return owner._index
 
     def _item_from_index_entry(self, res, target_name):
         """Create an Item from an index entry and skip entries with invalid meta."""
@@ -259,10 +324,17 @@ class Action:
 
         repo_json_path = os.path.join(self.repos_path, "repos.json")
         if not os.path.exists(repo_json_path):
-            with open(repo_json_path, 'w') as f:
-                json.dump([str(mlc_local_repo_path_expanded)], f, indent=2)
-                logger.info(
-                    f"Created repos.json in {os.path.dirname(self.repos_path)} and initialised with local cache folder path: {mlc_local_repo_path}")
+            # Same lock the register/unregister writers take, so a first run
+            # racing another one cannot have its fresh list clobbered, and
+            # readers never observe the file mid-creation.
+            with utils.file_lock_with_incremental_timeout(
+                    repo_json_path + ".lock"):
+                if not os.path.exists(repo_json_path):
+                    utils.save_json_atomic(
+                        repo_json_path, [
+                            str(mlc_local_repo_path_expanded)], indent=2)
+                    logger.info(
+                        f"Created repos.json in {os.path.dirname(self.repos_path)} and initialised with local cache folder path: {mlc_local_repo_path}")
 
         self.local_cache_path = os.path.join(mlc_local_repo_path, "cache")
         if not os.path.exists(self.local_cache_path):

--- a/mlc/action.py
+++ b/mlc/action.py
@@ -34,22 +34,17 @@ class Action:
     _repos = []  # list of Repo objects
     _index = None
 
-    # Never handed down to a delegate: copying the state fields would create a
-    # second copy that diverges from the owner's the moment either changes,
-    # and copying `parent` would collapse the chain the delegate resolves
-    # through (a grandparent would silently replace its parent).
+    # Never handed down to a delegate: copying these would diverge from the
+    # owner on the next write, and copying `parent` would collapse the chain.
     _NOT_INHERITED = ('parent', '_repos', '_index')
 
     def _state_owner(self):
         """Return the one object that owns repos/index state for this chain.
 
         Action subclasses are throwaway delegates - get_action() builds a fresh
-        one per dispatch - while the state they mutate has to outlive them: the
-        long-lived root (`default_parent`) is reused for every later
-        search()/find()/rm() in the same process. Resolving through that root
-        means a repo pulled by one delegate is visible to the next one at once,
-        instead of each delegate mutating a private copy that has to be pushed
-        back by hand.
+        one per dispatch - but the long-lived root (`default_parent`) is reused
+        for every later search()/find()/rm() in the same process. Resolving
+        through that root keeps every delegate looking at the same state.
 
         A parent that is not an Action (tests pass a stub carrying just
         repos_path) cannot own state, so there the delegate owns its own.

--- a/mlc/cache_action.py
+++ b/mlc/cache_action.py
@@ -22,9 +22,7 @@ class CacheAction(Action):
     """
 
     def __init__(self, parent=None):
-        # super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        self._inherit_from_parent(parent)
 
     def search(self, i):
         """
@@ -102,6 +100,10 @@ class CacheAction(Action):
         """
         i['target_name'] = "cache"
         # logger.debug(f"Removing cache with input: {i}")
+        # Deliberately the base implementation on the *base* receiver, not
+        # super().rm(i): Action.rm() calls self.search(), and going through
+        # this class's search() would filter out expired caches, i.e. leave
+        # exactly the entries a user runs `mlc rm cache` to get rid of.
         return self.parent.rm(i)
 
     def mark_tmp(self, i):

--- a/mlc/cfg_action.py
+++ b/mlc/cfg_action.py
@@ -8,9 +8,7 @@ class CfgAction(Action):
     def __init__(self, parent=None):
         if parent is None:
             parent = default_parent
-        #super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        self._inherit_from_parent(parent)
 
     def load(self, args):
         """

--- a/mlc/cfg_action.py
+++ b/mlc/cfg_action.py
@@ -4,6 +4,7 @@ from . import utils
 from .action import Action, default_parent
 from .logger import logger
 
+
 class CfgAction(Action):
     def __init__(self, parent=None):
         if parent is None:
@@ -13,21 +14,27 @@ class CfgAction(Action):
     def load(self, args):
         """
         Load the configuration.
-        
+
         Args:
             args (dict): Contains the configuration details such as file path, etc.
         """
-        #logger.info("In cfg load")
-        default_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
+        # logger.info("In cfg load")
+        default_config_path = os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__)),
+            'config.yaml')
         config_file = args.get('config_file', default_config_path)
         logger.info(f"In cfg load, config file = {config_file}")
         if not config_file or not os.path.exists(config_file):
-            logger.error(f"Error: Configuration file '{config_file}' not found.")
-            return {'return': 1, 'error': f"Error: Configuration file '{config_file}' not found."}
-        
-        #logger.info(f"Loading configuration from {config_file}")
-        
-        # Example loading YAML configuration (can be modified based on your needs)
+            logger.error(
+                f"Error: Configuration file '{config_file}' not found.")
+            return {
+                'return': 1, 'error': f"Error: Configuration file '{config_file}' not found."}
+
+        # logger.info(f"Loading configuration from {config_file}")
+
+        # Example loading YAML configuration (can be modified based on your
+        # needs)
         try:
             with open(config_file, 'r') as file:
                 config_data = yaml.safe_load(file)
@@ -36,5 +43,5 @@ class CfgAction(Action):
                 self.cfg = config_data
         except yaml.YAMLError as e:
             logger.error(f"Error loading YAML configuration: {e}")
-        
+
         return {'return': 0, 'config': self.cfg}

--- a/mlc/experiment_action.py
+++ b/mlc/experiment_action.py
@@ -3,6 +3,7 @@ from .logger import logger
 import os
 from . import utils
 
+
 class ExperimentAction(Action):
     def __init__(self, parent=None):
         self._inherit_from_parent(parent)
@@ -14,4 +15,3 @@ class ExperimentAction(Action):
     def list(self, args):
         logger.info("Listing all experiments.")
         return {'return': 0}
-

--- a/mlc/experiment_action.py
+++ b/mlc/experiment_action.py
@@ -5,9 +5,7 @@ from . import utils
 
 class ExperimentAction(Action):
     def __init__(self, parent=None):
-        #super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        self._inherit_from_parent(parent)
 
     def show(self, args):
         logger.info(f"Showing experiment with identifier: {args.details}")

--- a/mlc/index.py
+++ b/mlc/index.py
@@ -5,7 +5,6 @@ import yaml
 from .repo import Repo
 from datetime import datetime
 from .meta_schema import validate_meta
-from contextlib import contextmanager
 from filelock import Timeout
 from . import utils
 
@@ -62,7 +61,7 @@ class Index:
         """
         lock_file = self.modified_times_file + ".lock"
         try:
-            with self._file_lock_with_incremental_timeout(lock_file):
+            with utils.file_lock_with_incremental_timeout(lock_file):
                 # logger.debug(f"Lock acquired at {lock_file} for Loading Modified Times")
 
                 if os.path.exists(self.modified_times_file):
@@ -80,27 +79,13 @@ class Index:
             logger.error(f"Error acquiring lock {lock_file}: {e}")
             return {}
 
-    @contextmanager
-    def _file_lock_with_incremental_timeout(
-            self, lock_file, timeout_seconds=60):
-        """
-        Acquire a file lock by waiting up to a minute, then retrying once if it times out.
-
-        Thin wrapper kept for the existing call sites; the implementation is
-        shared with the repos.json writers in utils so there is only one
-        locking policy in the codebase.
-        """
-        with utils.file_lock_with_incremental_timeout(
-                lock_file, timeout_seconds):
-            yield
-
     def _save_modified_times(self):
         """
         Save updated mtimes in modified_times json file.
         """
         lock_file = self.modified_times_file + ".lock"
         try:
-            with self._file_lock_with_incremental_timeout(lock_file):
+            with utils.file_lock_with_incremental_timeout(lock_file):
                 # logger.debug(f"Lock acquired at {lock_file} for Saving Modified Times")
 
                 # logger.debug(f"Saving modified times to {self.modified_times_file}")
@@ -121,7 +106,7 @@ class Index:
         for folder_type, file_path in self.index_files.items():
             lock_file = file_path + ".lock"
             try:
-                with self._file_lock_with_incremental_timeout(lock_file):
+                with utils.file_lock_with_incremental_timeout(lock_file):
                     # logger.debug(f"Lock acquired at {lock_file} for Loading Index for {folder_type}")
 
                     if os.path.exists(file_path):
@@ -444,7 +429,7 @@ class Index:
             output_file = self.index_files[folder_type]
             lock_file = output_file + ".lock"
             try:
-                with self._file_lock_with_incremental_timeout(lock_file):
+                with utils.file_lock_with_incremental_timeout(lock_file):
                     # logger.debug(f"Lock acquired at {lock_file} for Saving Index for {folder_type}")
 
                     with open(output_file, "w") as f:

--- a/mlc/index.py
+++ b/mlc/index.py
@@ -6,7 +6,8 @@ from .repo import Repo
 from datetime import datetime
 from .meta_schema import validate_meta
 from contextlib import contextmanager
-from filelock import FileLock, Timeout
+from filelock import Timeout
+from . import utils
 
 
 class CustomJSONEncoder(json.JSONEncoder):
@@ -84,18 +85,13 @@ class Index:
             self, lock_file, timeout_seconds=60):
         """
         Acquire a file lock by waiting up to a minute, then retrying once if it times out.
-        """
-        try:
-            with FileLock(lock_file, timeout=timeout_seconds):
-                yield  # Control goes to the caller's 'with' block while the file lock is held
-                return
-        except Timeout:
-            logger.warning(
-                f"Timeout acquiring lock {lock_file} after {int(timeout_seconds)}s. "
-                f"Retrying once for another {int(timeout_seconds)}s..."
-            )
 
-        with FileLock(lock_file, timeout=timeout_seconds):
+        Thin wrapper kept for the existing call sites; the implementation is
+        shared with the repos.json writers in utils so there is only one
+        locking policy in the codebase.
+        """
+        with utils.file_lock_with_incremental_timeout(
+                lock_file, timeout_seconds):
             yield
 
     def _save_modified_times(self):

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -349,6 +349,16 @@ class RepoAction(Action):
             index.add_repo(repo_obj)
             logger.debug("Index file has been updated")
 
+            # search()/find()/rm() on any action dispatched through access()
+            # (RepoAction, ScriptAction, ...) delegate to self.parent, which
+            # is a different object than the one register_repo() just updated
+            # (get_action() constructs a fresh instance per dispatch). Without
+            # this, a search immediately after any pull in the same process
+            # would still see self.parent's pre-pull repos/index.
+            if self.parent is not None and self.parent is not self:
+                self.parent.repos = self.repos
+                self.parent._index = index
+
         return {'return': 0}
 
     def unregister_repo(self, repo_path):

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -16,17 +16,13 @@ from .index import Index
 def repos_json_lock(repos_file_path):
     """Serialize the read-modify-write of repos.json across mlc processes.
 
-    Registering and unregistering both read the whole list, change one entry
-    and write the list back. Two concurrent `mlc pull repo` runs would
-    otherwise both read the pre-change list and the slower writer would
-    overwrite the other's entry with a list that never contained it, so a repo
-    silently vanishes from repos.json (and `mlc rm repo` racing a pull can
-    resurrect one). Hold this lock across the whole read-modify-write.
+    Without this, two concurrent `mlc pull repo` runs can each read the same
+    list and the slower write silently drops the other's entry. Hold this
+    across the whole read-modify-write.
 
-    Keep the locked region narrow: nothing inside it may call back into a
-    function that takes the same lock (register_repo() unregisters conflicts
-    and pulls deps *before* entering it) or two lock objects on one file
-    deadlock within a single process.
+    Keep the locked region narrow - nothing inside it may call a function that
+    takes this same lock, or two FileLocks on one file deadlock within a
+    single process.
     """
     return utils.file_lock_with_incremental_timeout(
         repos_file_path + ".lock")
@@ -364,10 +360,8 @@ class RepoAction(Action):
         )
 
         if repo_obj:
-            # Both the reload above and this index update land on the shared
-            # state owner (see Action._state_owner()), so a search()/find()/rm()
-            # dispatched after this pull sees the new repo without anything
-            # having to be copied back onto self.parent by hand.
+            # Lands on the shared state owner (Action._state_owner()), so any
+            # search()/find()/rm() dispatched after this pull sees it too.
             index = Action.get_index(self)
             index.add_repo(repo_obj)
             logger.debug("Index file has been updated")

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -13,6 +13,25 @@ from .repo import Repo
 from .index import Index
 
 
+def repos_json_lock(repos_file_path):
+    """Serialize the read-modify-write of repos.json across mlc processes.
+
+    Registering and unregistering both read the whole list, change one entry
+    and write the list back. Two concurrent `mlc pull repo` runs would
+    otherwise both read the pre-change list and the slower writer would
+    overwrite the other's entry with a list that never contained it, so a repo
+    silently vanishes from repos.json (and `mlc rm repo` racing a pull can
+    resurrect one). Hold this lock across the whole read-modify-write.
+
+    Keep the locked region narrow: nothing inside it may call back into a
+    function that takes the same lock (register_repo() unregisters conflicts
+    and pulls deps *before* entering it) or two lock objects on one file
+    deadlock within a single process.
+    """
+    return utils.file_lock_with_incremental_timeout(
+        repos_file_path + ".lock")
+
+
 class RepoAction(Action):
     """
     ####################################################################################################################
@@ -46,9 +65,7 @@ class RepoAction(Action):
     GIT_FAST_FORWARD_FAILURE_PHRASE = "not possible to fast-forward"
 
     def __init__(self, parent=None):
-        # super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        self._inherit_from_parent(parent)
 
     def _build_pull_command(self, repo_path, branch=None, clone_depth=None,
                             fast_forward_only=False):
@@ -327,15 +344,17 @@ class RepoAction(Action):
         # Get the path to the repos.json file in $HOME/MLC
         repos_file_path = os.path.join(self.repos_path, 'repos.json')
 
-        with open(repos_file_path, 'r') as f:
-            repos_list = json.load(f)
+        with repos_json_lock(repos_file_path):
+            with open(repos_file_path, 'r') as f:
+                repos_list = json.load(f)
 
-        if repo_path not in repos_list:
-            repos_list.append(repo_path)
-            logger.info(f"Added new repo path: {repo_path}")
+            if repo_path not in repos_list:
+                repos_list.append(repo_path)
+                logger.info(f"Added new repo path: {repo_path}")
 
-        with open(repos_file_path, 'w') as f:
-            json.dump(repos_list, f, indent=2)
+            res = utils.save_json_atomic(repos_file_path, repos_list, indent=2)
+            if res['return'] > 0:
+                return res
             logger.info(f"Updated repos.json at {repos_file_path}")
 
         self.repos = self.load_repos_and_meta()
@@ -345,19 +364,13 @@ class RepoAction(Action):
         )
 
         if repo_obj:
+            # Both the reload above and this index update land on the shared
+            # state owner (see Action._state_owner()), so a search()/find()/rm()
+            # dispatched after this pull sees the new repo without anything
+            # having to be copied back onto self.parent by hand.
             index = Action.get_index(self)
             index.add_repo(repo_obj)
             logger.debug("Index file has been updated")
-
-            # search()/find()/rm() on any action dispatched through access()
-            # (RepoAction, ScriptAction, ...) delegate to self.parent, which
-            # is a different object than the one register_repo() just updated
-            # (get_action() constructs a fresh instance per dispatch). Without
-            # this, a search immediately after any pull in the same process
-            # would still see self.parent's pre-pull repos/index.
-            if self.parent is not None and self.parent is not self:
-                self.parent.repos = self.repos
-                self.parent._index = index
 
         return {'return': 0}
 
@@ -1043,16 +1056,18 @@ def rm_repo(repo_path, repos_file_path, force_remove):
 def unregister_repo(repo_path, repos_file_path):
     logger.info(f"Unregistering the repo in path {repo_path}")
 
-    with open(repos_file_path, 'r') as f:
-        repos_list = json.load(f)
+    with repos_json_lock(repos_file_path):
+        with open(repos_file_path, 'r') as f:
+            repos_list = json.load(f)
 
-    if repo_path in repos_list:
-        repos_list.remove(repo_path)
-        with open(repos_file_path, 'w') as f:
-            json.dump(repos_list, f, indent=2)
-        logger.info(f"Path: {repo_path} has been removed.")
-    else:
-        logger.info(
-            f"Path: {repo_path} not found in {repos_file_path}. Nothing to be unregistered!")
+        if repo_path in repos_list:
+            repos_list.remove(repo_path)
+            res = utils.save_json_atomic(repos_file_path, repos_list, indent=2)
+            if res['return'] > 0:
+                return res
+            logger.info(f"Path: {repo_path} has been removed.")
+        else:
+            logger.info(
+                f"Path: {repo_path} not found in {repos_file_path}. Nothing to be unregistered!")
 
     return {'return': 0}

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -269,7 +269,15 @@ Main Script Meta:""")
 
             if result['return'] == 0:
                 self.repos = self.load_repos_and_meta()
-                self.index = Index(self.repos_path, self.repos)
+                self._index = Index(self.repos_path, self.repos)
+
+                # search()/find()/rm() on this action delegate to self.parent
+                # (see ScriptAction.search), so the refreshed repos/index must
+                # also land there, or a search immediately after this auto-pull
+                # would still consult self.parent's stale, pre-pull state.
+                if self.parent is not None and self.parent is not self:
+                    self.parent.repos = self.repos
+                    self.parent._index = self._index
 
                 # Try to find the script path again after pulling
                 script_path = self.find_target_folder("script")

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -267,10 +267,6 @@ Main Script Meta:""")
             })
 
             if result['return'] == 0:
-                # Needed on self so the find_target_folder() retry just below
-                # sees the newly pulled repo. register_repo() (called via the
-                # access() pull above) already refreshes the index itself and
-                # propagates it to self.parent for search()/find()/rm().
                 self.repos = self.load_repos_and_meta()
 
                 # Try to find the script path again after pulling

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -5,7 +5,6 @@ import sys
 import importlib
 import json
 import inspect
-from .index import Index
 from . import utils
 from .error_codes import get_error_guidance
 from .logger import logger
@@ -268,21 +267,11 @@ Main Script Meta:""")
             })
 
             if result['return'] == 0:
+                # Needed on self so the find_target_folder() retry just below
+                # sees the newly pulled repo. register_repo() (called via the
+                # access() pull above) already refreshes the index itself and
+                # propagates it to self.parent for search()/find()/rm().
                 self.repos = self.load_repos_and_meta()
-                # Must be self._index, not self.index: get_index() (used by
-                # search()/find()/rm()) reads self._index, lazily building it
-                # only if still None (see Action.get_index/__init__). Writing
-                # self.index here would leave self._index untouched, so the
-                # refresh would silently never be seen.
-                self._index = Index(self.repos_path, self.repos)
-
-                # search()/find()/rm() on this action delegate to self.parent
-                # (see ScriptAction.search), so the refreshed repos/index must
-                # also land there, or a search immediately after this auto-pull
-                # would still consult self.parent's stale, pre-pull state.
-                if self.parent is not None and self.parent is not self:
-                    self.parent.repos = self.repos
-                    self.parent._index = self._index
 
                 # Try to find the script path again after pulling
                 script_path = self.find_target_folder("script")

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -269,6 +269,11 @@ Main Script Meta:""")
 
             if result['return'] == 0:
                 self.repos = self.load_repos_and_meta()
+                # Must be self._index, not self.index: get_index() (used by
+                # search()/find()/rm()) reads self._index, lazily building it
+                # only if still None (see Action.get_index/__init__). Writing
+                # self.index here would leave self._index untouched, so the
+                # refresh would silently never be seen.
                 self._index = Index(self.repos_path, self.repos)
 
                 # search()/find()/rm() on this action delegate to self.parent

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -37,11 +37,9 @@ class ScriptAction(Action):
     Using both alias and UID: <script_alias>,<script_uid> (e.g., detect-os,5b4e0237da074764)
 
     """
-    parent = None
 
     def __init__(self, parent=None):
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        self._inherit_from_parent(parent)
 
     def search(self, i):
         """

--- a/mlc/utils.py
+++ b/mlc/utils.py
@@ -12,8 +12,30 @@ import shutil
 import tarfile
 import zipfile
 import logging
+from contextlib import contextmanager
+from filelock import FileLock, Timeout
 from packaging import version
 logger = logging.getLogger("mlc")
+
+
+@contextmanager
+def file_lock_with_incremental_timeout(lock_file, timeout_seconds=60):
+    """
+    Acquire a file lock by waiting up to a minute, then retrying once if it times out.
+    """
+    try:
+        with FileLock(lock_file, timeout=timeout_seconds):
+            yield  # Control goes to the caller's 'with' block while the file lock is held
+            return
+    except Timeout:
+        waited = int(timeout_seconds)
+        logger.warning(
+            f"Timeout acquiring lock {lock_file} after {waited}s. "
+            f"Retrying once for another {waited}s..."
+        )
+
+    with FileLock(lock_file, timeout=timeout_seconds):
+        yield
 
 
 def get_repo_version(repo_path):
@@ -412,6 +434,40 @@ def save_json(file_name, meta):
             json.dump(meta, f, indent=4)
         return {'return': 0, 'error': ''}
     except Exception as e:
+        return {'return': 1, 'error': str(e)}
+
+
+def save_json_atomic(file_name, meta, indent=4):
+    """
+    Saves the provided meta data to a JSON file, replacing it atomically.
+
+    The data is written to a temporary file in the same directory and then
+    renamed over the target, so a reader that is not holding the file lock
+    either sees the previous content or the new content, never a half-written
+    file. Use this for files that unlocked readers load (e.g. repos.json).
+
+    Args:
+        file_name (str): The name of the file where the JSON data will be saved.
+        meta (dict): The dictionary containing the data to be saved in JSON format.
+        indent (int): Indentation used in the written JSON.
+
+    Returns:
+        dict: A dictionary indicating success or failure of the operation.
+            - 'return' (int): 0 if the operation was successful, > 0 if an error occurred.
+            - 'error' (str): Error message, if any error occurred.
+    """
+    temp_file_name = f"{file_name}.tmp.{os.getpid()}"
+    try:
+        with open(temp_file_name, 'w') as f:
+            json.dump(meta, f, indent=indent)
+        os.replace(temp_file_name, file_name)
+        return {'return': 0, 'error': ''}
+    except Exception as e:
+        if os.path.exists(temp_file_name):
+            try:
+                os.remove(temp_file_name)
+            except OSError:
+                pass
         return {'return': 1, 'error': str(e)}
 
 

--- a/tests/test_action_state_sharing.py
+++ b/tests/test_action_state_sharing.py
@@ -1,0 +1,120 @@
+import os
+import tempfile
+import unittest
+
+from mlc.action import Action
+from mlc.cache_action import CacheAction
+from mlc.repo_action import RepoAction
+from mlc.script_action import ScriptAction
+
+
+class _StubParent:
+    """A non-Action parent, as the apptainer test passes."""
+
+    def __init__(self, repos_path):
+        self.repos_path = repos_path
+
+
+class ActionStateSharingTest(unittest.TestCase):
+    """repos/index live on one owner per process, not on each delegate.
+
+    get_action() builds a fresh delegate per dispatch, so any state a delegate
+    keeps privately is thrown away when it returns - and any state it read at
+    construction time is a snapshot that goes stale as soon as another delegate
+    changes something.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.previous_cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.previous_cwd)
+        os.chdir(self.temp_dir.name)
+
+        self.previous_mlc_repos = os.environ.get("MLC_REPOS")
+        self.addCleanup(self._restore_env)
+        os.environ["MLC_REPOS"] = os.path.join(self.temp_dir.name, "repos")
+
+        self.root = Action()
+
+    def _restore_env(self):
+        if self.previous_mlc_repos is None:
+            os.environ.pop("MLC_REPOS", None)
+        else:
+            os.environ["MLC_REPOS"] = self.previous_mlc_repos
+
+    def test_delegate_reads_the_owners_repos(self):
+        for action_class in (RepoAction, ScriptAction, CacheAction):
+            with self.subTest(action_class=action_class.__name__):
+                self.assertIs(
+                    action_class(self.root).repos, self.root.repos)
+
+    def test_write_through_delegate_reaches_the_owner(self):
+        delegate = RepoAction(self.root)
+        sentinel = ["replaced-by-delegate"]
+
+        delegate.repos = sentinel
+
+        self.assertIs(self.root.repos, sentinel)
+        self.assertIs(delegate.repos, sentinel)
+
+    def test_existing_delegate_is_not_left_holding_a_stale_copy(self):
+        # The order that matters in production: a delegate is constructed, then
+        # a *different* delegate (a pull) replaces repos, then the first one is
+        # used again for a search.
+        searcher = ScriptAction(self.root)
+        puller = RepoAction(self.root)
+        sentinel = ["pulled"]
+
+        puller.repos = sentinel
+
+        self.assertIs(searcher.repos, sentinel)
+
+    def test_index_is_built_once_and_shared(self):
+        root_index = self.root.get_index()
+
+        self.assertIs(RepoAction(self.root).get_index(), root_index)
+        self.assertIs(ScriptAction(self.root).get_index(), root_index)
+
+    def test_nested_delegates_resolve_to_the_root(self):
+        nested = CacheAction(ScriptAction(self.root))
+        sentinel = ["nested"]
+
+        nested.repos = sentinel
+
+        self.assertIs(self.root.repos, sentinel)
+
+    def test_delegate_with_non_action_parent_owns_its_state(self):
+        # Nothing to delegate to, so the delegate must not leak writes onto an
+        # unrelated object or blow up reading its own repos.
+        delegate = ScriptAction(_StubParent(self.temp_dir.name))
+
+        self.assertEqual(delegate.repos, [])
+        delegate.repos = ["own"]
+        self.assertEqual(delegate.repos, ["own"])
+        self.assertEqual(self.root.repos, self.root.repos)
+
+    def test_delegate_without_parent_owns_its_state(self):
+        delegate = RepoAction(None)
+
+        self.assertIsNone(delegate.parent)
+        self.assertIsNotNone(delegate.repos_path)
+
+    def test_registering_a_repo_is_visible_to_later_delegates(self):
+        repo_path = os.path.join(self.temp_dir.name, "repos", "some@repo")
+        os.makedirs(repo_path)
+        uid = "0123456789abcdef"
+        with open(os.path.join(repo_path, "meta.yaml"), "w") as f:
+            f.write(f"alias: some@repo\nuid: {uid}\n")
+
+        res = RepoAction(self.root).register_repo(
+            repo_path, {"alias": "some@repo", "uid": uid, "path": repo_path})
+        self.assertEqual(res["return"], 0)
+
+        # A search dispatched after the pull gets a brand new delegate.
+        paths = [repo.path for repo in ScriptAction(self.root).repos]
+        self.assertIn(repo_path, paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repos_json_concurrency.py
+++ b/tests/test_repos_json_concurrency.py
@@ -1,0 +1,110 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from mlc.action import Action
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+WORKERS = 3
+REPOS_PER_WORKER = 12
+
+# Registers REPOS_PER_WORKER distinct repos in a tight loop. Run concurrently,
+# these interleave their repos.json read-modify-write; without a lock the
+# slower writer overwrites the other's entry with a list that never contained
+# it (lost update), or a reader catches the file mid-write (JSONDecodeError).
+WORKER_SCRIPT = """
+import os, sys
+from mlc.action import Action
+from mlc.repo_action import RepoAction
+
+repos_path, wid, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+action = Action()
+action.parent = None
+
+for j in range(count):
+    tag = "w%s_r%d" % (wid, j)
+    repo_path = os.path.join(repos_path, tag)
+    uid = ("%016x" % (abs(hash(tag)) % (16 ** 16)))
+    RepoAction(action).register_repo(
+        repo_path, {"alias": tag, "uid": uid, "path": repo_path})
+"""
+
+
+class ReposJsonConcurrencyTest(unittest.TestCase):
+    """Concurrent `mlc pull repo` runs must not drop each other's entries."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.previous_cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.previous_cwd)
+        os.chdir(self.temp_dir.name)
+
+        self.repos_path = os.path.join(self.temp_dir.name, "repos")
+        self.previous_mlc_repos = os.environ.get("MLC_REPOS")
+        self.addCleanup(self._restore_env)
+        os.environ["MLC_REPOS"] = self.repos_path
+
+        # Creates repos.json seeded with the local repo.
+        Action()
+
+    def _restore_env(self):
+        if self.previous_mlc_repos is None:
+            os.environ.pop("MLC_REPOS", None)
+        else:
+            os.environ["MLC_REPOS"] = self.previous_mlc_repos
+
+    def _seed_repo(self, tag):
+        repo_path = os.path.join(self.repos_path, tag)
+        os.makedirs(repo_path, exist_ok=True)
+        uid = "%016x" % (abs(hash(tag)) % (16 ** 16))
+        with open(os.path.join(repo_path, "meta.yaml"), "w") as f:
+            f.write(f"alias: {tag}\nuid: {uid}\n")
+        return tag
+
+    def _env(self):
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = REPO_ROOT if not existing_pythonpath else REPO_ROOT + \
+            os.pathsep + existing_pythonpath
+        return env
+
+    def test_concurrent_register_repo_keeps_every_entry(self):
+        expected = set()
+        for wid in range(WORKERS):
+            for j in range(REPOS_PER_WORKER):
+                expected.add(self._seed_repo(f"w{wid}_r{j}"))
+
+        processes = [
+            subprocess.Popen(
+                [sys.executable, "-c", WORKER_SCRIPT, self.repos_path,
+                 str(wid), str(REPOS_PER_WORKER)],
+                env=self._env(),
+                cwd=self.temp_dir.name,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True)
+            for wid in range(WORKERS)
+        ]
+
+        for process in processes:
+            stdout, stderr = process.communicate(timeout=300)
+            self.assertEqual(
+                process.returncode, 0,
+                f"worker failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+
+        with open(os.path.join(self.repos_path, "repos.json")) as f:
+            registered = {os.path.basename(path) for path in json.load(f)}
+
+        self.assertEqual(
+            expected - registered, set(),
+            "entries were lost from repos.json by a concurrent writer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**The original bug.** `call_script_module_function()` refreshed `self.index` after a successful auto-pull, but `get_index()` (used by `search`/`find`/`rm`) reads `self._index` — a different attribute since PR #205's lazy-indexing refactor renamed it there but missed this call site. A search immediately after an auto-pull in the same process silently found nothing.

Fixing the attribute name alone wasn't sufficient: `ScriptAction.search()`/`find()`/`rm()` delegate to `self.parent`, not `self`, and a direct `mlc pull repo` followed by a search (no auto-pull involved) had the identical bug. The propagation needed to live in `register_repo()` (`repo_action.py`), the one place every pull already routes through — see the last commit's description for the full history of that back-and-forth.

**Two follow-on hardening changes, once the above exposed them:**

1. **Shared state instead of copy-back.** Every `Action` subclass (`RepoAction`, `ScriptAction`, `CacheAction`, `ExperimentAction`, `CfgAction`) is a throwaway delegate — `get_action()` builds a fresh one per dispatch — but was previously initialized via `self.__dict__.update(vars(parent))`, a one-time *copy* of `repos`/`_index`. Any two delegates could silently diverge the moment either wrote to its copy, which is exactly what caused the bug above. `Action.repos` is now a property, and `get_index()` resolves through the new `Action._state_owner()`, which walks the `parent` chain to the single long-lived root (`default_parent`) reused across a process. A write from any delegate is now immediately visible to every other delegate — no more manual copy-back. Subclasses call the new `self._inherit_from_parent(parent)` instead of the old `__dict__.update`.

2. **`repos.json` read-modify-write wasn't safe under concurrent `mlc` processes.** `register_repo()`/`unregister_repo()` both read the whole list, change one entry, and write it back with no lock — two concurrent `mlc pull repo` runs could lose one another's entry, or a reader could catch the file mid-write. Reproduced on an unpatched install: of 3 concurrent registrars, one died with `JSONDecodeError` and its entries vanished. Added `repos_json_lock()` (`repo_action.py`) held across the whole read-modify-write, and `utils.save_json_atomic()` (temp file + `os.replace`) so unlocked readers never see a partial file. `Index`'s own file-lock helper was moved to `utils.py` so there's one locking policy instead of two, and its now-redundant wrapper method in `Index` was removed (call sites now call the `utils` helper directly).

Also added a "Comment style" section to `AGENTS.md`: comment *why* code is this way, concisely; leave "why it used to be different" to commit messages, not code comments that outlive the PR.

## Test plan

- [x] Reproduced pre-fix: `run` (triggering auto-pull) followed by `search` in the same process returns an empty list
- [x] Reproduced pre-fix (2nd form): a direct `mlc pull repo` followed by a search, no auto-pull involved
- [x] Verified fix via the original repro (`access()` for run, then `search()`)
- [x] Verified fix with `run()` called directly (isolating the propagation logic from `access()`'s extra dispatch layer)
- [x] Verified fix with two separate top-level `mlc.action.access()` calls, matching typical library usage
- [x] `tests/test_action_state_sharing.py` (new) — 8 cases pinning that `repos`/`get_index()` resolve through one shared owner; 5 of 8 fail against the pre-fix `__dict__.update` copy pattern
- [x] `tests/test_repos_json_concurrency.py` (new) — 3 concurrent processes registering 12 repos each; all 36 survive. Reproduced the pre-fix crash (`JSONDecodeError`, lost entries) with the same harness against an unpatched install
- [x] End-to-end on a fresh `MLC_REPOS`: auto-pull → register → find → run in one process, run with deps, find/rm cache, re-pull, alias-conflict pull (unregister+register, confirmed no deadlock from the new lock), rm repo
- [x] Both `.github/scripts` checks (`test_repo_pull_force.py`, `test_error_guidance.py`) pass
- [x] Full existing test suite passes (29 tests, up from 13 at PR open)
- [x] `autopep8 -a --diff` clean on every file touched in this PR
- [x] Plain CLI usage (`mlcr`, `mlc find script`, `mlc reindex`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
