### PR TITLE
Remove legacy min_mlc_version compat mechanism

### DIFF
--- a/automation/script/lint.py
+++ b/automation/script/lint.py
@@ -98,7 +98,6 @@ TOP_LEVEL_KEY_ORDER = [
     "tags",
     "tags_help",
     "private",
-    "min_mlc_version",
     "mlc_compat",
 
     # Cache
@@ -174,7 +173,6 @@ SECTION_GROUPS = [
       "tags",
       "tags_help",
       "private",
-      "min_mlc_version",
       "mlc_compat"]),
     ("# Cache",
      ["cache",

--- a/automation/script/meta_schema.py
+++ b/automation/script/meta_schema.py
@@ -40,7 +40,6 @@ TOP_LEVEL_SCHEMA = {
     "sort": INT,
     "category_sort": INT,
     "private": BOOL,
-    "min_mlc_version": STR,
 
     # Environment
     "env": DICT,        # dict[str, str]

--- a/automation/script/module.py
+++ b/automation/script/module.py
@@ -611,9 +611,8 @@ class ScriptAutomation(Automation):
         meta = script_item.meta
         path = script_item.path
 
-        # Check mlcflow version requirements
-        # mlc_compat (new): multi-entry, per-entry messages, warn or block
-        # min_mlc_version (legacy): single threshold, always blocks
+        # Check mlcflow version requirements (mlc_compat: multi-entry,
+        # per-entry messages, warn or block)
         script_alias = meta.get('alias', '')
         try:
             from script.compat import get_installed_version, check_mlc_compat, format_compat_notice
@@ -635,18 +634,6 @@ class ScriptAutomation(Automation):
                         )}
                     else:
                         self.logger.warning(notice)
-            else:
-                # Fall back to legacy min_mlc_version (single threshold, always
-                # blocks)
-                min_mlc_version = meta.get('min_mlc_version', '').strip()
-                if min_mlc_version and current_mlc_version:
-                    if utils.compare_versions(
-                            current_mlc_version, min_mlc_version) < 0:
-                        return {'return': 1, 'error': (
-                            'This script requires mlcflow >= {} (installed: {}) '
-                            '— please upgrade: pip install --upgrade mlcflow'.format(
-                                min_mlc_version, current_mlc_version)
-                        )}
         except Exception as e:
             # Never let a compat-check failure block script execution
             self.logger.debug('mlc_compat check skipped: {}'.format(e))

--- a/mlc/meta_schema.py
+++ b/mlc/meta_schema.py
@@ -40,7 +40,6 @@ TOP_LEVEL_SCHEMA = {
     "sort": INT,
     "category_sort": INT,
     "private": BOOL,
-    "min_mlc_version": STR,
 
     # Environment
     "env": DICT,        # dict[str, str]


### PR DESCRIPTION
## Summary
- Removes the legacy `min_mlc_version` version-gate key and its enforcement code from the bundled `ScriptAutomation` engine, keeping only the `mlc_compat` mechanism.
- Drops `min_mlc_version` from the meta schema (`mlc/meta_schema.py`, `automation/script/meta_schema.py`) and from lint key ordering (`automation/script/lint.py`).

## Why
`min_mlc_version` was a single-threshold, always-blocking legacy check that predates `mlc_compat` (which supports multiple entries, per-entry messages, and warn-vs-block). It was superseded by `mlc_compat` and is no longer needed.

Companion content fix: mlcommons/mlperf-automations removes the now-unenforceable `min_mlc_version: 2.2.0` key from `get-dataset-cognata-mlcommons/meta.yaml`, which was hard-blocking that script once the bundled engine started correctly enforcing this legacy key.

## Test plan
- [x] `python3 -m pytest tests/` — 20 passed
- [x] Repo-wide grep confirms no remaining `min_mlc_version` references outside `build/` (gitignored)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>