### PR TITLE
Share repos/index state across Action delegates instead of copying it

### DIFF
--- a/mlc/action.py
+++ b/mlc/action.py
@@ -15,6 +15,7 @@ from .index import Index
 from .repo import Repo
 from .item import Item
 from .error_codes import WarningCode
+from .state import MLCState
 
 # Base class for actions
 
@@ -24,9 +25,40 @@ class Action:
     cfg = None
     action_type = None
     logger = None
-    local_repo = None
-    current_repo_path = None
-    repos = []  # list of Repo objects
+    local_cache_path = None
+
+    # Startup configuration, handed down to a delegate by value because it does
+    # not change after __init__ bootstraps the root. Anything that *does* change
+    # while mlc runs belongs on MLCState instead, so that a write from one
+    # delegate is visible to all the others.
+    _CONFIG_ATTRS = ('repos_path', 'local_cache_path', 'cfg', 'logger')
+
+    # Read/written as plain attributes throughout the codebase; routing them
+    # through self.state means `self.repos = ...` in a delegate updates the one
+    # shared object rather than rebinding a private copy that dies with it.
+    @property
+    def repos(self):
+        return self.state.repos
+
+    @repos.setter
+    def repos(self, value):
+        self.state.repos = value
+
+    @property
+    def local_repo(self):
+        return self.state.local_repo
+
+    @local_repo.setter
+    def local_repo(self, value):
+        self.state.local_repo = value
+
+    @property
+    def current_repo_path(self):
+        return self.state.current_repo_path
+
+    @current_repo_path.setter
+    def current_repo_path(self, value):
+        self.state.current_repo_path = value
 
     # Main access function to simulate a Python interface for CLI
     def access(self, options):
@@ -217,9 +249,11 @@ class Action:
             return None
 
     def get_index(self):
-        if self._index is None:
-            self._index = Index(self.repos_path, self.repos)
-        return self._index
+        # Cached on the shared state, so the index a delegate updates during a
+        # pull is the same one a later search reads.
+        if self.state.index is None:
+            self.state.index = Index(self.repos_path, self.repos)
+        return self.state.index
 
     def _item_from_index_entry(self, res, target_name):
         """Create an Item from an index entry and skip entries with invalid meta."""
@@ -230,7 +264,23 @@ class Action:
             return None
         return it
 
-    def __init__(self):
+    def __init__(self, parent=None):
+        self.parent = parent
+
+        if parent is not None:
+            # A delegate built by get_action(): share the dispatcher's state
+            # object and take its startup config. A parent that is not an
+            # Action (test stubs carrying just repos_path) has no state to
+            # share, so the delegate gets its own; attributes the stub lacks
+            # fall back to the class defaults.
+            self.state = getattr(parent, 'state', None) or MLCState()
+            for attr in self._CONFIG_ATTRS:
+                if hasattr(parent, attr):
+                    setattr(self, attr, getattr(parent, attr))
+            return
+
+        self.state = MLCState()
+
         setup_logging(log_path=os.getcwd(), log_file='.mlc-log.txt')
         self.logger = logger
 
@@ -270,7 +320,6 @@ class Action:
 
         self.repos = self.load_repos_and_meta()
         # logger.info(f"In Action class: {self.repos_path}")
-        self._index = None
 
     def add(self, i):
         """

--- a/mlc/cache_action.py
+++ b/mlc/cache_action.py
@@ -21,11 +21,6 @@ class CacheAction(Action):
 
     """
 
-    def __init__(self, parent=None):
-        # super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
-
     def search(self, i):
         """
     ####################################################################################################################

--- a/mlc/cfg_action.py
+++ b/mlc/cfg_action.py
@@ -6,11 +6,7 @@ from .logger import logger
 
 class CfgAction(Action):
     def __init__(self, parent=None):
-        if parent is None:
-            parent = default_parent
-        #super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
+        super().__init__(parent if parent is not None else default_parent)
 
     def load(self, args):
         """

--- a/mlc/experiment_action.py
+++ b/mlc/experiment_action.py
@@ -4,11 +4,6 @@ import os
 from . import utils
 
 class ExperimentAction(Action):
-    def __init__(self, parent=None):
-        #super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
-
     def show(self, args):
         logger.info(f"Showing experiment with identifier: {args.details}")
         return {'return': 0}

--- a/mlc/repo_action.py
+++ b/mlc/repo_action.py
@@ -45,11 +45,6 @@ class RepoAction(Action):
     GIT_MISSING_BRANCH_PHRASE = "did not match any file(s) known to git"
     GIT_FAST_FORWARD_FAILURE_PHRASE = "not possible to fast-forward"
 
-    def __init__(self, parent=None):
-        # super().__init__(parent)
-        self.parent = parent
-        self.__dict__.update(vars(parent))
-
     def _build_pull_command(self, repo_path, branch=None, clone_depth=None,
                             fast_forward_only=False):
         pull_command = ['git', '-C', repo_path, 'pull']

--- a/mlc/script_action.py
+++ b/mlc/script_action.py
@@ -5,7 +5,6 @@ import sys
 import importlib
 import json
 import inspect
-from .index import Index
 from . import utils
 from .error_codes import get_error_guidance
 from .logger import logger
@@ -38,11 +37,6 @@ class ScriptAction(Action):
     Using both alias and UID: <script_alias>,<script_uid> (e.g., detect-os,5b4e0237da074764)
 
     """
-    parent = None
-
-    def __init__(self, parent=None):
-        self.parent = parent
-        self.__dict__.update(vars(parent))
 
     def search(self, i):
         """
@@ -268,9 +262,6 @@ Main Script Meta:""")
             })
 
             if result['return'] == 0:
-                self.repos = self.load_repos_and_meta()
-                self.index = Index(self.repos_path, self.repos)
-
                 # Try to find the script path again after pulling
                 script_path = self.find_target_folder("script")
                 if not script_path or not self._content_repo_registered():

--- a/mlc/state.py
+++ b/mlc/state.py
@@ -1,0 +1,21 @@
+class MLCState:
+    """Mutable state shared by every Action instance in a process.
+
+    Action subclasses are throwaway delegates - get_action() builds a fresh one
+    per dispatch and drops it when the call returns - but the state they mutate
+    has to outlive them, since the long-lived root (`default_parent`) is what
+    serves every later search()/find()/rm().
+
+    Delegates hold a *reference* to one of these, never a copy, which is what
+    makes a repo registered by RepoAction visible to a later ScriptAction
+    search in the same process.
+
+    Everything here is a product of load_repos_and_meta(), so the fields stay
+    consistent with each other by being refreshed together.
+    """
+
+    def __init__(self):
+        self.repos = []           # list of Repo objects
+        self.index = None         # Index, built lazily by Action.get_index()
+        self.local_repo = None    # "local,<uid>" of the local repo
+        self.current_repo_path = None  # registered repo containing cwd, if any

--- a/tests/test_action_shared_state.py
+++ b/tests/test_action_shared_state.py
@@ -1,0 +1,154 @@
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from mlc.action import Action
+from mlc.action_factory import get_action
+from mlc.cache_action import CacheAction
+from mlc.repo_action import RepoAction
+from mlc.script_action import ScriptAction
+
+
+class _StubParent:
+    """A non-Action parent, as tests/test_script_action_apptainer.py passes."""
+
+    def __init__(self, repos_path=None):
+        self.repos_path = repos_path
+
+
+class ActionSharedStateTest(unittest.TestCase):
+    """get_action() builds a throwaway delegate per dispatch, so anything it
+    writes to repos/index has to land on the long-lived root that serves the
+    next search - not on a private copy that dies with the delegate."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.previous_cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.previous_cwd)
+        os.chdir(self.temp_dir.name)
+
+        self.previous_mlc_repos = os.environ.get("MLC_REPOS")
+        self.addCleanup(self._restore_env)
+        os.environ["MLC_REPOS"] = os.path.join(self.temp_dir.name, "repos")
+
+        self.root = Action()
+
+    def _restore_env(self):
+        if self.previous_mlc_repos is None:
+            os.environ.pop("MLC_REPOS", None)
+        else:
+            os.environ["MLC_REPOS"] = self.previous_mlc_repos
+
+    def _make_repo(self, alias, uid, script_alias, script_uid, tags):
+        """A minimal on-disk MLC repo holding a single script."""
+        path = os.path.join(self.temp_dir.name, alias)
+        script_dir = os.path.join(path, "script", script_alias)
+        os.makedirs(script_dir)
+        with open(os.path.join(path, "meta.yaml"), "w") as f:
+            yaml.safe_dump({"alias": alias, "name": alias, "uid": uid}, f)
+        with open(os.path.join(script_dir, "meta.yaml"), "w") as f:
+            yaml.safe_dump({
+                "alias": script_alias,
+                "uid": script_uid,
+                "automation_alias": "script",
+                "automation_uid": "5b4e0237da074764",
+                "tags": list(tags),
+            }, f)
+        return path
+
+    def test_every_delegate_shares_one_state_object(self):
+        delegates = [get_action(t, self.root)
+                     for t in ("repo", "script", "cache", "experiment")]
+
+        for delegate in delegates:
+            self.assertIs(delegate.state, self.root.state)
+
+    def test_delegate_write_to_repos_is_visible_on_the_root(self):
+        repo_action = get_action("repo", self.root)
+
+        # Assignment, not in-place mutation: this is what register_repo() does,
+        # and it is what used to rebind a private copy onto the delegate.
+        repo_action.repos = repo_action.repos + ["sentinel"]
+
+        self.assertIn("sentinel", self.root.repos)
+        self.assertEqual(self.root.repos, repo_action.repos)
+
+    def test_root_write_to_repos_is_visible_on_a_delegate(self):
+        script_action = get_action("script", self.root)
+        self.root.repos = self.root.repos + ["sentinel"]
+
+        self.assertIn("sentinel", script_action.repos)
+
+    def test_index_built_by_a_delegate_is_the_one_the_root_serves(self):
+        # Order matters: the delegate exists before any index does, which is
+        # the case register_repo() hits. An index it builds must be the index a
+        # later search reads, or the pull's add_repo() call is thrown away.
+        repo_action = get_action("repo", self.root)
+        self.assertIsNone(self.root.state.index)
+
+        index = repo_action.get_index()
+
+        self.assertIs(self.root.get_index(), index)
+        self.assertIs(get_action("script", self.root).get_index(), index)
+
+    def test_local_repo_and_current_repo_path_are_shared(self):
+        repo_action = get_action("repo", self.root)
+        repo_action.local_repo = "acme,0011223344556677"
+        repo_action.current_repo_path = "/somewhere/acme"
+
+        self.assertEqual(self.root.local_repo, "acme,0011223344556677")
+        self.assertEqual(self.root.current_repo_path, "/somewhere/acme")
+
+    def test_registering_a_repo_is_visible_to_a_later_search(self):
+        """The original bug: `mlc run script` auto-pulls, and the search that
+        follows in the same process finds nothing."""
+        repo_path = self._make_repo(
+            "acme@demo-automations", "aa11bb22cc33dd44",
+            "demo-script", "1122334455667788", ("demo", "shared-state"))
+
+        # The pull is dispatched to a fresh delegate that is then dropped...
+        repo_action = get_action("repo", self.root)
+        res = repo_action.register_repo(
+            repo_path,
+            {"alias": "acme@demo-automations", "uid": "aa11bb22cc33dd44"})
+        self.assertEqual(res["return"], 0, res)
+        del repo_action
+
+        # ...and the search that follows is served by the root.
+        self.assertIn(repo_path, [r.path for r in self.root.repos])
+
+        found = get_action("script", self.root).search(
+            {"tags": "demo,shared-state"})
+        self.assertEqual(found["return"], 0, found)
+        self.assertEqual([item.path for item in found["list"]],
+                         [os.path.join(repo_path, "script", "demo-script")])
+
+    def test_startup_config_is_inherited(self):
+        delegate = get_action("script", self.root)
+
+        self.assertEqual(delegate.repos_path, self.root.repos_path)
+        self.assertEqual(delegate.local_cache_path, self.root.local_cache_path)
+        self.assertIs(delegate.parent, self.root)
+
+    def test_non_action_parent_gets_its_own_state(self):
+        """A stub parent carries no state to share, so the delegate owns its
+        own rather than blowing up or reaching for a global."""
+        delegate = ScriptAction(_StubParent(self.temp_dir.name))
+
+        self.assertIsNot(delegate.state, self.root.state)
+        self.assertEqual(delegate.repos_path, self.temp_dir.name)
+        self.assertEqual(delegate.repos, [])
+
+    def test_subclasses_do_not_reimplement_the_constructor(self):
+        """The state sharing lives in Action.__init__; a subclass that defines
+        its own __init__ silently opts out of it."""
+        for cls in (RepoAction, ScriptAction, CacheAction):
+            self.assertIs(cls.__init__, Action.__init__, cls.__name__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
get_action() builds a fresh delegate per dispatch, but every subclass started with `self.__dict__.update(vars(parent))` - a snapshot copy of the parent's attributes. The copy shares the *reference* to `repos`, so the two stay linked until someone rebinds; `register_repo()` does exactly that with `self.repos = self.load_repos_and_meta()`, which points only the delegate's name at the new list and leaves the long-lived root holding the pre-pull one.

Since the delegate is dropped when the call returns and the root is what serves every later search()/find()/rm(), a pull followed by a search in the same process searched a stale repo list and a stale index. The refresh in call_script_module_function() could not help: it wrote to ScriptAction's own copy (and to `self.index`, while get_index() reads `_index`).

Move the mutable state onto MLCState, which delegates hold by reference and never copy. `repos`, `local_repo` and `current_repo_path` become properties routed through it, so an assignment inside any delegate updates the object every other delegate sees, and get_index() caches there too. Action.__init__ now takes the parent and does this for every subclass, so RepoAction, ScriptAction, CacheAction and ExperimentAction no longer need a constructor at all; CfgAction keeps one only for its default_parent fallback.

With the state shared, the refresh at the auto-pull site is dead code - register_repo() already reloads the repos and adds the new one to the index - so it is deleted rather than fixed.

tests/test_action_shared_state.py pins the sharing and the original bug; 8 of its 9 cases fail without this change.

## ✅ PR Checklist

### ✅ Testing & CI
- [ ] Have tested the changes in my local environment, else have properly conveyed in the PR description
- [ ] The change includes a GitHub Action to test the script(if it is possible to be added).
- [ ] No existing GitHub Actions are failing because of this change.

### 📚 Documentation
- [ ] README or help docs are updated for new features or changes.
- [ ] CLI help messages are meaningful and complete.

### 📁 File Hygiene & Output Handling
- [ ] No unintended files (e.g., logs, cache, temp files, __pycache__, output folders) are committed.

### 🛡️ Safety & Security
- [ ] No secrets or credentials are committed.
- [ ] Paths, shell commands, and environment handling are safe and portable.

### 🙌 Contribution Hygiene
- [ ] PR title and description are concise and clearly state the purpose of the change.
- [ ] Related issues (if any) are properly referenced using `Fixes #` or `Closes #`.
- [ ] All reviewer feedback has been addressed.

