### PR TITLE
Make rm-cache race test deterministic and cover convert_env_to_script

### DIFF
--- a/tests/test_convert_env_to_script.py
+++ b/tests/test_convert_env_to_script.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for convert_env_to_script list handling.
+
+A list-valued env key used to be rendered with str(), which dropped a Python
+repr (``['a', 'b']``) into the generated shell assignment.  It is now joined
+with the platform separator.  These tests pin that behaviour for both
+platforms and guard the '+KEY' append path that shares the same branch.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+# Ensure the automation directory is on sys.path so script.module can be
+# imported without a full mlcflow install.
+_automation_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'automation')
+)
+if _automation_dir not in sys.path:
+    sys.path.insert(0, _automation_dir)
+
+
+# os_info fixtures mirroring automation/utils.py, declared explicitly so the
+# Windows expectations can be checked from any host.
+UNIX_OS_INFO = {
+    'platform': 'linux',
+    'set_env': 'export ${key}="${value}"',
+    'env_separator': ':',
+    'env_quote': '"',
+    'env_var': '${env_var}',
+}
+
+WINDOWS_OS_INFO = {
+    'platform': 'windows',
+    'set_env': 'set ${key}=${value}',
+    'env_separator': ';',
+    'env_quote': "'",
+    'env_var': '%env_var%',
+}
+
+
+class ConvertEnvToScriptListTest(unittest.TestCase):
+    def _convert(self, env, os_info):
+        from script.module import convert_env_to_script
+        return convert_env_to_script(env, os_info)
+
+    def test_unix_list_is_joined_not_python_repr(self):
+        """A plain key with a list value must be joined with ':', and must not
+        leak Python repr syntax (brackets / quoted items) into the script."""
+        script = self._convert({'MY_LIST': ['a', 'b', 'c']}, UNIX_OS_INFO)
+
+        self.assertEqual(script, ['export MY_LIST="a:b:c"'])
+        line = script[0]
+        for repr_artifact in ('[', ']', "'"):
+            self.assertNotIn(
+                repr_artifact, line,
+                f"Python repr artifact {repr_artifact!r} leaked into: {line}")
+
+    def test_windows_list_uses_windows_separator(self):
+        script = self._convert({'MY_LIST': ['a', 'b', 'c']}, WINDOWS_OS_INFO)
+
+        self.assertEqual(script, ['set MY_LIST=a;b;c'])
+
+    def test_non_list_values_are_unchanged(self):
+        """The list branch must not capture scalars."""
+        script = self._convert({'MY_STR': 'plain', 'MY_INT': 7}, UNIX_OS_INFO)
+
+        self.assertEqual(
+            script, ['export MY_INT="7"', 'export MY_STR="plain"'])
+
+    def test_append_key_still_appends_existing_value(self):
+        """'+KEY' keeps its append semantics -- it shares the if/elif chain
+        with the list branch, so it is worth pinning here."""
+        script = self._convert({'+PATH': ['/x', '/y']}, UNIX_OS_INFO)
+
+        self.assertEqual(script, ['export PATH="/x:/y:${PATH}"'])
+
+    def test_append_key_with_custom_separator(self):
+        """A non-alphanumeric first character after '+' selects the separator."""
+        script = self._convert({'+ CFLAGS': ['-O1', '-O2']}, UNIX_OS_INFO)
+
+        self.assertEqual(script, ['export CFLAGS="-O1 -O2 ${CFLAGS}"'])
+
+    @unittest.skipIf(sys.platform == 'win32', 'bash not available on Windows')
+    def test_generated_unix_script_is_valid_bash_and_round_trips(self):
+        """The generated assignment must parse under bash and the variable must
+        hold the joined value -- this is the failure the change was made for."""
+        script = self._convert(
+            {'MY_LIST': ['one', 'two', 'three']}, UNIX_OS_INFO)
+        body = '\n'.join(script)
+
+        syntax_check = subprocess.run(
+            ['bash', '-n', '-c', body], capture_output=True, text=True)
+        self.assertEqual(
+            syntax_check.returncode, 0,
+            f"Generated script is not valid bash:\n{body}\n{syntax_check.stderr}")
+
+        result = subprocess.run(
+            ['bash', '-c', f'{body}\nprintf %s "$MY_LIST"'],
+            capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, 'one:two:three')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -7,9 +7,11 @@ Thread safety tests for core mlc operations:
 
 import json
 import os
+import shutil
 import tempfile
 import threading
 import unittest
+from unittest import mock
 
 from mlc.action import Action
 from mlc.cache_action import CacheAction
@@ -30,8 +32,10 @@ class ConcurrentRmCacheTest(unittest.TestCase):
 
         action = Action()
         action.parent = None
-        for name, tags in [("cache-a", "get,dataset,a"), ("cache-b", "get,dataset,b")]:
-            res = action.add({"target_name": "cache", "item": name, "tags": tags})
+        for name, tags in [("cache-a", "get,dataset,a"),
+                           ("cache-b", "get,dataset,b")]:
+            res = action.add(
+                {"target_name": "cache", "item": name, "tags": tags})
             self.assertEqual(res["return"], 0)
 
     def _restore_env(self):
@@ -42,31 +46,62 @@ class ConcurrentRmCacheTest(unittest.TestCase):
 
     def test_concurrent_rm_cache_does_not_raise(self):
         """Two threads deleting the same cache item must not raise an exception,
-        and the item must be gone from the filesystem and index afterwards."""
+        and the item must be gone from the filesystem and index afterwards.
+
+        The race is forced rather than left to the scheduler: rm() checks
+        os.path.exists(item_path) and only then calls shutil.rmtree(), so the
+        window is a few microseconds wide and is almost never hit naturally.
+        The barrier below holds both threads at the entry to rmtree -- which
+        they can only reach after passing that existence check -- and the lock
+        then serialises the deletions, so the second caller always meets an
+        already-removed directory.
+        """
         errors = []
         # Record the path of the item before deletion
         action_pre = Action()
         action_pre.parent = None
-        res_pre = action_pre.search({"target_name": "cache", "tags": "get,dataset,a"})
+        res_pre = action_pre.search(
+            {"target_name": "cache", "tags": "get,dataset,a"})
         self.assertEqual(res_pre["return"], 0)
-        self.assertGreater(len(res_pre["list"]), 0, "Item must exist before test")
+        self.assertGreater(len(res_pre["list"]),
+                           0, "Item must exist before test")
         item_path = res_pre["list"][0].path
+
+        real_rmtree = shutil.rmtree
+        both_threads_past_exists_check = threading.Barrier(2, timeout=30)
+        deletion_order = threading.Lock()
+
+        def racing_rmtree(path, *args, **kwargs):
+            # Only coordinate on the contended item; any other rmtree call
+            # (temp dirs, index internals) must pass straight through or it
+            # would pair up with the barrier and deadlock.
+            if os.path.abspath(path) != os.path.abspath(item_path):
+                return real_rmtree(path, *args, **kwargs)
+            # Blocking here *before* deleting guarantees the item is still on
+            # disk and in the index for the other thread's search, so both
+            # threads are certain to reach this point and the barrier cannot
+            # time out.
+            both_threads_past_exists_check.wait()
+            with deletion_order:
+                return real_rmtree(path, *args, **kwargs)
 
         def rm_cache(tags):
             try:
                 action = Action()
                 action.parent = None
-                # Call rm directly with target_name set (same as CacheAction.rm does)
+                # Call rm directly with target_name set (same as CacheAction.rm
+                # does)
                 action.rm({"target_name": "cache", "tags": tags, "f": True})
             except Exception as exc:
                 errors.append(exc)
 
-        t1 = threading.Thread(target=rm_cache, args=("get,dataset,a",))
-        t2 = threading.Thread(target=rm_cache, args=("get,dataset,a",))
-        t1.start()
-        t2.start()
-        t1.join()
-        t2.join()
+        with mock.patch.object(shutil, "rmtree", racing_rmtree):
+            t1 = threading.Thread(target=rm_cache, args=("get,dataset,a",))
+            t2 = threading.Thread(target=rm_cache, args=("get,dataset,a",))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
 
         self.assertEqual(errors, [], f"Unexpected exceptions: {errors}")
         self.assertFalse(
@@ -76,7 +111,8 @@ class ConcurrentRmCacheTest(unittest.TestCase):
         # Index must also not list the item anymore
         action_post = Action()
         action_post.parent = None
-        res_post = action_post.search({"target_name": "cache", "tags": "get,dataset,a"})
+        res_post = action_post.search(
+            {"target_name": "cache", "tags": "get,dataset,a"})
         self.assertEqual(res_post["return"], 0)
         self.assertEqual(
             len(res_post["list"]), 0,
@@ -98,7 +134,8 @@ class ConcurrentMarkTmpTest(unittest.TestCase):
 
         action = Action()
         action.parent = None
-        res = action.add({"target_name": "cache", "item": "shared-cache", "tags": "get,shared"})
+        res = action.add(
+            {"target_name": "cache", "item": "shared-cache", "tags": "get,shared"})
         self.assertEqual(res["return"], 0)
         self.cache_path = res["path"]
 
@@ -146,7 +183,8 @@ class ConcurrentMarkTmpTest(unittest.TestCase):
         def patched_search(self_inner, i):
             result = original_search(self_inner, i)
             # Simulate a concurrent write that adds 'extra-tag' to the meta file
-            # after search() has already populated item.meta but before the lock.
+            # after search() has already populated item.meta but before the
+            # lock.
             if os.path.exists(meta_json):
                 with open(meta_json) as fh:
                     on_disk = json.load(fh)

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -68,6 +68,11 @@ class ConcurrentRmCacheTest(unittest.TestCase):
         item_path = res_pre["list"][0].path
 
         real_rmtree = shutil.rmtree
+        # 2 parties: one per racing thread, so neither proceeds until both have
+        # cleared the existence check. The timeout is a safety net rather than
+        # part of the choreography -- if a thread never arrives, wait() raises
+        # BrokenBarrierError, which rm_cache records in `errors` and the
+        # assertion below reports, instead of hanging CI until it is killed.
         both_threads_past_exists_check = threading.Barrier(2, timeout=30)
         deletion_order = threading.Lock()
 


### PR DESCRIPTION
Addresses the two open test-coverage items from the review on #267. Test-only — no production code is touched.

## 1. `ConcurrentRmCacheTest` was flaky, not deterministic

The test relied on the scheduler to collide two threads in the window between `rm()`'s `os.path.exists(item_path)` check and its `shutil.rmtree()` call. That window is a few microseconds wide, so the collision almost never happened.

Measured with `mlc/action.py` reverted to `main` (i.e. the `FileNotFoundError` guard removed), the test detected the bug in **1 of 13 runs** — CI would have stayed green with the bug present.

The race is now forced:

- a 2-party `threading.Barrier` holds both threads at the entry to `rmtree`, which they can only reach *after* passing the existence check;
- a lock then serialises the deletions, so the second caller always meets an already-removed directory.

Blocking *before* the delete also guarantees the item is still on disk and in the index when the other thread searches, so both threads are certain to reach the barrier and it cannot time out. Any other `rmtree` call (temp dirs, index internals) passes straight through so it never pairs with the barrier.

| | guard present | guard reverted to `main` |
|---|---|---|
| before | 13/13 pass | 12/13 pass — detected 1/13 |
| after | 6/6 pass | **0/6 pass — detected 6/6** |

## 2. `convert_env_to_script` list handling had no coverage

It has changed twice on this branch — first dropping list-valued vars on Unix, then joining them with the platform separator — with no test either time, while affecting every mlperf-automations script whose env carries a list value.

New `tests/test_convert_env_to_script.py` pins:

- Unix: `['a','b','c']` → `export MY_LIST="a:b:c"`, and asserts no Python repr artifacts (`[`, `]`, `'`) leak into the script;
- Windows: same list → `set MY_LIST=a;b;c`;
- scalars are untouched by the new `elif` branch;
- `+PATH` and `+ CFLAGS` keep their append semantics — they share the `if`/`elif` chain with the list branch, so they are worth pinning alongside it;
- the generated Unix assignment parses under `bash -n` and round-trips to `one:two:three`.

`os_info` is built as an explicit fixture mirroring `automation/utils.py`, so the Windows expectations are checked from any host.

Against the pre-fix `str()` behaviour the three list tests fail and the three guard tests pass, as expected.

## Verification

- Full suite: **50 passed**.
- Both mutation checks above reproduce deterministically in each direction.
- `autopep8 --in-place -a` applied to both files to match `.github/workflows/format.yml`.

## Note, not fixed here

Joining removes the Python repr, but the generated `export K="..."` still lets shell metacharacters in element values expand — `['$(date)']` becomes `export K="$(date)"` and substitutes at source time. That is pre-existing for scalar values too and out of scope for this PR, but worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
