### PR TITLE
docs: define the required PR review format for AI agents

### DIFF
--- a/.claude/skill.md
+++ b/.claude/skill.md
@@ -191,6 +191,41 @@ pip install -e .
 python -m pytest tests/
 ```
 
+### "I need to review a PR"
+
+Full spec — required structure, severity definitions, evidence rules — is in
+**AGENTS.md → "PR review format"**. Follow it exactly; the short version:
+
+```
+> attribution block: AI-performed, on whose request, what was inspected
+## Verdict                  ← 2-3 sentences + merge recommendation
+## 🔴 High severity         ← omit any tier with no findings
+## 🟠 Medium severity
+## 🟡 Low severity
+## Suggested path to merge  ← numbered, ordered, concrete
+```
+
+Investigate before writing:
+```bash
+gh pr diff <N> --repo mlcommons/mlcflow
+SHA=$(gh pr view <N> --repo mlcommons/mlcflow --json headRefOid -q .headRefOid)
+git fetch --depth 1 https://github.com/mlcommons/mlcflow.git refs/pull/<N>/head && git checkout FETCH_HEAD
+```
+
+- Read the **callers and callees** of changed code, not just the diff. A comment
+  claiming "we now read X" is only true if some caller actually reads X — grep
+  for readers before believing it.
+- Check whether CI actually runs for the change: compare the touched paths
+  against each workflow's `paths:` filter. `automation/**` is **not** covered by
+  `test-unit.yml`.
+- Check whether the change duplicates existing coverage in `tests/`.
+- Run the changed shell functions where you can; quote the real output as evidence.
+
+Post as a plain comment so no required review slot is consumed:
+```bash
+gh pr comment <N> --repo mlcommons/mlcflow --body-file review.md
+```
+
 ---
 
 ## Quick reference: key classes and where they live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,3 +502,61 @@ avoids the prompt.
 - `dev` is kept in sync with `main` and is only used for urgent merges that
   need to bypass the normal approval process.
 - Never push directly to `main`.
+
+---
+
+## PR review format
+
+When an agent is asked to review a pull request, the posted review must follow
+the structure below. The goal is that a maintainer can triage by severity
+without reading the whole comment, and that every claim is checkable.
+
+### Required structure
+
+1. **Attribution block** (blockquote, first thing in the comment) — state that
+   the review was performed by an AI agent, on whose request, what was
+   inspected, and that it is input to human review rather than a substitute.
+   Reviews posted from a human's account without this block are not acceptable.
+2. **Verdict** — two or three sentences: what the PR is trying to do, whether
+   it does it, and a merge recommendation.
+3. **Findings grouped under severity headings**, highest first. Omit a heading
+   entirely if it has no findings — never emit an empty section.
+   - `## 🔴 High severity`
+   - `## 🟠 Medium severity`
+   - `## 🟡 Low severity`
+4. **Suggested path to merge** — a numbered, ordered list of concrete actions.
+
+### Severity definitions
+
+| Level | Use when |
+|---|---|
+| 🔴 High | Incorrect behaviour, data loss or unintended filesystem/network mutation, a security issue, or code whose comments/docs contradict what it actually does. Also: the PR's central mechanism does not work. |
+| 🟠 Medium | Works, but is wrong under a documented mode or realistic configuration; missing tests for new user-facing behaviour; CI that does not exercise the change; duplicated or racy logic. |
+| 🟡 Low | Style, dead code, redundancy, naming, fragile-but-working test setup, PR hygiene (title/description/docs), pre-existing gaps the PR merely surfaces. |
+
+### Rules for individual findings
+
+- Give each finding a `###` heading that states the defect as a claim, not a
+  topic — "Marker file is written but never read", not "Marker file".
+- Cite `path:line` (or a permalink at the PR head SHA) for every claim.
+- Prefer evidence over assertion. Paste the grep, the failing command, or the
+  observed output that demonstrates the problem. If a claim was verified by
+  running code, say so; if it is reasoned-but-unverified, say that too.
+- Mark pre-existing issues as pre-existing. Do not charge them against the PR,
+  but do flag them when the PR makes them easier to reach.
+- End each High/Medium finding with a concrete **Fix:** line.
+- Do not pad. No praise sections, no restating the diff, no findings invented to
+  fill a severity tier.
+
+### Mechanics
+
+```bash
+gh pr diff <N> --repo mlcommons/mlcflow          # the change
+gh pr view <N> --repo mlcommons/mlcflow --json headRefOid -q .headRefOid
+# read the *callers and callees* of changed code, not just the diff —
+# most real findings live in the gap between the two
+gh pr comment <N> --repo mlcommons/mlcflow --body-file review.md
+```
+
+Post as a regular comment (`gh pr comment`), not as a formal approval or
+change-request review — an agent should not consume a required review slot.


### PR DESCRIPTION
## What

Adds a **PR review format** section to `AGENTS.md` and a matching compact playbook to `.claude/skill.md`, so that AI-agent-authored PR reviews land in a consistent, triageable shape.

## Why

Agent reviews are already being posted on this repo (e.g. #297). Without a stated convention they vary in structure, bury serious findings next to nits, and sometimes omit that an AI produced them. This pins down:

- **Attribution** — a required blockquote naming the agent, on whose request, what was inspected, and that it is input to human review rather than a substitute. Reviews posted from a human account without it are not acceptable.
- **Severity triage** — findings grouped under 🔴 High / 🟠 Medium / 🟡 Low with explicit definitions, so a maintainer can decide what blocks merge without reading the whole comment. Empty tiers are omitted rather than emitted blank.
- **Evidence over assertion** — claim-style headings, `path:line` citations, pasted greps/command output, an explicit note on whether a claim was verified by running code, pre-existing issues marked as such, and a concrete `Fix:` line per High/Medium finding.
- **No padding** — no praise sections, no restating the diff, no findings invented to fill a tier.
- **Post as a plain comment** (`gh pr comment`), not an approval or change-request review, so an agent never consumes a required review slot.

The `.claude/skill.md` playbook also records the investigation steps that actually surfaced real findings in practice:

- Read the **callers and callees** of changed code, not just the diff — a comment claiming "we now read X" is only true if some caller reads X.
- Check whether CI actually runs for the change by comparing touched paths against each workflow's `paths:` filter — `automation/**` is **not** covered by `test-unit.yml`.
- Check whether new tests duplicate existing coverage in `tests/`.

## Scope

Documentation only — no code, no CI, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)